### PR TITLE
Fix #14: MockServer expectations abort during unrelated panic

### DIFF
--- a/src/mock_server.rs
+++ b/src/mock_server.rs
@@ -240,7 +240,7 @@ impl Drop for MockServer {
         debug!("Verify mock expectations.");
         if !run!(self.verify()) {
             if std::thread::panicking() {
-                debug!("Verification failed, but already panicking.");
+                debug!("Verification failed: mock expectations have not been satisfied.");
             } else {
                 panic!("Verification failed: mock expectations have not been satisfied.");
             }

--- a/src/mock_server.rs
+++ b/src/mock_server.rs
@@ -239,7 +239,11 @@ impl Drop for MockServer {
     fn drop(&mut self) {
         debug!("Verify mock expectations.");
         if !run!(self.verify()) {
-            panic!("Verification failed: mock expectations have not been satisfied.");
+            if std::thread::panicking() {
+                debug!("Verification failed, but already panicking.");
+            } else {
+                panic!("Verification failed: mock expectations have not been satisfied.");
+            }
         }
         debug!("Killing server actor.");
         self.server_actor.actor_ref.kill().unwrap();

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -39,6 +39,22 @@ async fn panics_if_the_expectation_is_not_satisfied() {
 }
 
 #[async_std::test]
+#[should_panic]
+async fn panic_during_expectation_does_not_crash() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let response = ResponseTemplate::new(200);
+    Mock::given(method("GET"))
+        .respond_with(response)
+        .expect(1..)
+        .mount(&mock_server)
+        .await;
+
+    // Act - start a panic
+    assert!(false);
+}
+
+#[async_std::test]
 async fn simple_route_mock() {
     // Arrange
     let mock_server = MockServer::start().await;


### PR DESCRIPTION
I think this should solve [this issue](https://github.com/LukeMathWalker/wiremock-rs/issues/14).

I used `debug` for when the thread is already panicking, not sure if it should be a higher level log.