### PR TITLE
Derive Clone for Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -15,13 +15,13 @@ use std::{collections::HashMap, fmt};
 /// ### Implementation notes:
 /// We can't use `http_types::Request` directly in our `Match::matches` signature:
 /// it requires having mutable access to the request to extract the body (which gets
-/// consumed when read!).  
+/// consumed when read!).
 /// It would also require `matches` to be async, which is cumbersome due to the lack of async traits.
 ///
 /// We introduce our `Request` type to perform this extraction once when the request
 /// arrives in the mock serve, store the result and pass an immutable reference to it
 /// to all our matchers.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Request {
     pub url: Url,
     pub method: Method,


### PR DESCRIPTION
With the current API, it is not possible to save owned values of Request
in a Match implementation, because Match is only given a reference to a
Request, and Request does not implement Clone. If you wanted to store a
list of Requests and iterate over them and make assertions on them after
the fact, this would not be possible unless you could Clone owned values
of Request from their references.