### PR TITLE
simplify links in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,12 +113,8 @@
 //!
 //! More request matchers can be added to those provided out-of-the-box to handle common usecases.
 //!
-//! [`MockServer`]: struct.MockServer.html
-//! [`Mock`]: struct.Mock.html
-//! [`Match`]: trait.Match.html
-//! [`start`]: struct.MockServer.html#method.start
-//! [`expect`]: struct.Mock.html#method.expect
-//! [`matchers`]: matchers/index.html
+//! [`start`]: MockServer::start
+//! [`expect`]: Mock::expect
 //! [GitHub repository]: https://github.com/LukeMathWalker/wiremock-rs
 //! [`mockito`]: https://docs.rs/mockito/
 //! [`httpmock`]: https://docs.rs/httpmock/

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -7,9 +7,6 @@
 //! as input automatically implement [`Match`] and can be used where a matcher is expected.
 //!
 //! Check [`Match`]'s documentation for examples.
-//!
-//! [`Match`]: ../trait.Match.html
-//! [`Request`]: ../struct.Request.html
 use crate::{Match, Request};
 use http_types::headers::{HeaderName, HeaderValue};
 use http_types::Method;
@@ -62,7 +59,7 @@ where
 /// ```
 pub struct MethodExactMatcher(Method);
 
-/// Shorthand for [`MethodExactMatcher::new`](struct.MethodExactMatcher.html).
+/// Shorthand for [`MethodExactMatcher::new`].
 pub fn method<T>(method: T) -> MethodExactMatcher
 where
     T: TryInto<Method>,
@@ -149,7 +146,7 @@ impl Match for MethodExactMatcher {
 /// ```
 pub struct PathExactMatcher(String);
 
-/// Shorthand for [`PathExactMatcher::new`](struct.PathExactMatcher.html).
+/// Shorthand for [`PathExactMatcher::new`].
 pub fn path<T>(path: T) -> PathExactMatcher
 where
     T: Into<String>,
@@ -232,7 +229,7 @@ impl Match for PathExactMatcher {
 /// ```
 pub struct PathRegexMatcher(Regex);
 
-/// Shorthand for [`PathRegexMatcher::new`](struct.PathRegexMatcher.html).
+/// Shorthand for [`PathRegexMatcher::new`].
 pub fn path_regex<T>(path: T) -> PathRegexMatcher
 where
     T: Into<String>,
@@ -285,7 +282,7 @@ impl Match for PathRegexMatcher {
 /// ```
 pub struct HeaderExactMatcher(HeaderName, HeaderValue);
 
-/// Shorthand for [`HeaderExactMatcher::new`](struct.HeaderExactMatcher.html).
+/// Shorthand for [`HeaderExactMatcher::new`].
 pub fn header<K, V>(key: K, value: V) -> HeaderExactMatcher
 where
     K: TryInto<HeaderName>,
@@ -361,7 +358,7 @@ impl Match for HeaderExactMatcher {
 /// ```
 pub struct HeaderExistsMatcher(HeaderName);
 
-/// Shorthand for [`HeaderExistsMatcher::new`](struct.HeaderExistsMatcher.html).
+/// Shorthand for [`HeaderExistsMatcher::new`].
 pub fn header_exists<K>(key: K) -> HeaderExistsMatcher
 where
     K: TryInto<HeaderName>,
@@ -470,7 +467,7 @@ impl BodyExactMatcher {
     }
 }
 
-/// Shorthand for [`BodyExactMatcher::json`](struct.BodyExactMatcher.html).
+/// Shorthand for [`BodyExactMatcher::json`].
 pub fn body_json<T>(body: T) -> BodyExactMatcher
 where
     T: Serialize,
@@ -478,7 +475,7 @@ where
     BodyExactMatcher::json(body)
 }
 
-/// Shorthand for [`BodyExactMatcher::string`](struct.BodyExactMatcher.html).
+/// Shorthand for [`BodyExactMatcher::string`].
 pub fn body_string<T>(body: T) -> BodyExactMatcher
 where
     T: Into<String>,
@@ -486,7 +483,7 @@ where
     BodyExactMatcher::string(body)
 }
 
-/// Shorthand for [`BodyExactMatcher::bytes`](struct.BodyExactMatcher.html).
+/// Shorthand for [`BodyExactMatcher::bytes`].
 pub fn body_bytes<T>(body: T) -> BodyExactMatcher
 where
     T: Into<Vec<u8>>,
@@ -538,7 +535,7 @@ impl BodyContainsMatcher {
     }
 }
 
-/// Shorthand for [`BodyContainsMatcher::string`](struct.BodyContainsMatcher.html).
+/// Shorthand for [`BodyContainsMatcher::string`].
 pub fn body_string_contains<T>(body: T) -> BodyContainsMatcher
 where
     T: Into<String>,
@@ -610,7 +607,7 @@ impl QueryParamExactMatcher {
     }
 }
 
-/// Shorthand for [`QueryParamExactMatcher::new`](struct.QueryParamExactMatcher.html).
+/// Shorthand for [`QueryParamExactMatcher::new`].
 pub fn query_param<K, V>(key: K, value: V) -> QueryParamExactMatcher
 where
     K: Into<String>,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -102,9 +102,6 @@ use std::time::Duration;
 ///     assert_eq!(status.as_u16(), 200);
 /// }
 /// ```
-///
-/// [`Mock`]: struct.Mock.html
-/// [`Request`]: struct.Request.html
 pub trait Match: Send + Sync {
     /// Given a reference to a `Request`, determine if it should match or not given
     /// a specific criterion.
@@ -208,9 +205,8 @@ impl Debug for Matcher {
 ///
 /// Both `register` and `mount` are asynchronous methods - don't forget to `.await` them!
 ///
-/// [`MockServer`]: struct.MockServer.html
-/// [`register`]: struct.MockServer.html#method.register
-/// [`mount`]: #method.mount
+/// [`register`]: MockServer::register
+/// [`mount`]: Mock::mount
 #[derive(Debug)]
 pub struct Mock {
     pub(crate) matchers: Vec<Matcher>,
@@ -225,9 +221,6 @@ pub struct Mock {
 }
 
 /// A fluent builder to construct a [`Mock`] instance given matchers and a [`ResponseTemplate`].
-///
-/// [`Mock`]: struct.Mock.html
-/// [`ResponseTemplate`]: struct.ResponseTemplate.html
 #[derive(Debug)]
 pub struct MockBuilder {
     pub(crate) matchers: Vec<Matcher>,
@@ -237,8 +230,6 @@ impl Mock {
     /// Start building a `Mock` specifying the first matcher.
     ///
     /// It returns an instance of [`MockBuilder`].
-    ///
-    /// [`MockBuilder`]: struct.MockBuilder.html
     pub fn given<M: 'static + Match>(matcher: M) -> MockBuilder {
         MockBuilder {
             matchers: vec![Matcher(Box::new(matcher))],
@@ -291,7 +282,7 @@ impl Mock {
     /// }
     /// ```
     ///
-    /// [`matchers`]: matchers/index.html
+    /// [`matchers`]: crate::matchers
     pub fn up_to_n_times(mut self, n: u64) -> Mock {
         assert!(n > 0, "n must be strictly greater than 0!");
         self.max_n_matches = Some(n);
@@ -351,8 +342,6 @@ impl Mock {
     ///     // The `MockServer` will shutdown peacefully, without panicking.
     /// }
     /// ```
-    ///
-    /// [`MockServer`]: struct.MockServer.html
     pub fn expect<T: Into<Times>>(mut self, r: T) -> Mock {
         let range = r.into();
         self.expectation = range;
@@ -365,25 +354,20 @@ impl Mock {
     ///
     /// [`mount`] is an asynchronous method, make sure to `.await` it!
     ///
-    /// [`MockServer`]: struct.MockServer.html
-    /// [`register`]: struct.MockServer.html#method.register
-    /// [`mount`]: #method.mount
+    /// [`register`]: MockServer::register
+    /// [`mount`]: Mock::mount
     pub async fn mount(self, server: &MockServer) {
         server.register(self).await;
     }
 
     /// Build an instance of `http_types::Response` from the [`ResponseTemplate`] associated
     /// with a `Mock`.
-    ///
-    /// [`ResponseTemplate`]: struct.ResponseTemplate.html
     pub fn response(&self) -> Response {
         self.response.generate_response()
     }
 
     /// Build an instance of `http_types::Response` from the [`ResponseTemplate`] associated
     /// with a `Mock`.
-    ///
-    /// [`ResponseTemplate`]: struct.ResponseTemplate.html
     pub(crate) fn delay(&self) -> &Option<Duration> {
         self.response.delay()
     }
@@ -394,8 +378,7 @@ impl MockBuilder {
     ///
     /// **All** specified [`matchers`] must match for the overall [`Mock`] to match an incoming request.
     ///
-    /// [`matchers`]: matchers/index.html
-    /// [`Mock`]: struct.Mock.html
+    /// [`matchers`]: crate::matchers
     pub fn and<M: Match + 'static>(mut self, matcher: M) -> Self {
         self.matchers.push(Matcher(Box::new(matcher)));
         self
@@ -407,11 +390,8 @@ impl MockBuilder {
     /// `respond_with` finalises the `MockBuilder` and returns you a [`Mock`] instance, ready to
     /// be [`register`]ed or [`mount`]ed on a [`MockServer`]!
     ///
-    /// [`Mock`]: struct.Mock.html
-    /// [`MockServer`]: struct.MockServer.html
-    /// [`ResponseTemplate`]: struct.ResponseTemplate.html
-    /// [`register`]: struct.MockServer.html#method.register
-    /// [`mount`]: #method.mount
+    /// [`register`]: MockServer::register
+    /// [`mount`]: Mock::mount
     pub fn respond_with(self, template: ResponseTemplate) -> Mock {
         Mock {
             matchers: self.matchers,
@@ -447,8 +427,7 @@ impl MockBuilder {
 /// let times: Times = (..=15).into();
 /// ```
 ///
-/// [`Mock`]: struct.Mock.html
-/// [`expect`]: struct.Mock.html#method.expect
+/// [`expect`]: Mock::expect
 #[derive(Debug)]
 pub struct Times(TimesEnum);
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,9 +9,9 @@ use std::{collections::HashMap, fmt};
 /// Each matcher gets an immutable reference to a `Request` instance in the [`matches`] method
 /// defined in the [`Match`] trait.
 ///
-/// [`MockServer`]: struct.MockServer.html
-/// [`matches`]: trait.Match.html
-/// [`Match`]: trait.Match.html
+/// [`MockServer`]: crate::MockServer
+/// [`matches`]: crate::Match::matches
+/// [`Match`]: crate::Match
 ///
 /// ### Implementation notes:
 /// We can't use `http_types::Request` directly in our `Match::matches` signature:

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 /// The blueprint for the response returned by a [`MockServer`] when a [`Mock`] matches on an incoming request.
 ///
-/// [`Mock`]: struct.Mock.html
-/// [`MockServer`]: struct.MockServer.html
+/// [`Mock`]: crate::Mock
+/// [`MockServer`]: crate::MockServer
 #[derive(Clone, Debug)]
 pub struct ResponseTemplate {
     mime: Option<http_types::Mime>,
@@ -276,6 +276,8 @@ impl ResponseTemplate {
     ///     assert!(res.is_err());
     /// }
     /// ```
+    ///
+    /// [`MockServer`]: crate::mock_server::MockServer
     pub fn set_delay(mut self, delay: Duration) -> Self {
         self.delay = Some(delay);
 


### PR DESCRIPTION
Rust 1.48 enables [easier linking in docs](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#easier-linking-in-rustdoc).

I used this feature to simplify links in docs.