### PR TITLE
Add missing tokio feature for task::LocalSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ regex = "1"
 futures-timer = "3.0.2"
 futures = "0.3.5"
 hyper = "0.13.8"
-tokio = { version = "0.2", features = ["rt-core"] }
+tokio = { version = "0.2", features = ["rt-core", "rt-util"] }
 deadpool = "0.6.0"
 async-trait = "0.1.42"
 once_cell = "1.5.2"


### PR DESCRIPTION
Seems like wiremock v0.4 forgot to enabled this feature, which is required for using tokio::task::LocalSet. This causes breakage in every downstream create that doesn't have this feature enabled (we don't, it seems). Enabling this feature downstream makes this crate compile, but if needed, wiremock should enable this feature itself.

Not sure how this went undetected here, since I don't see it anywhere in the dependencies. 