### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT/Apache-2.0"
 
 repository = "https://github.com/LukeMathWalker/wiremock-rs"
 documentation = "https://docs.rs/wiremock/"
-readme = "README.md"
 
 description = "HTTP mocking to test Rust applications."
 


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).