### PR TITLE
Non-breaking named mocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "actix-macros"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
+checksum = "32d550809c1471a3ed937cb2afefd7cba179a6ac4a0cb46361b3541bfcad7084"
 dependencies = [
  "quote",
  "syn",
@@ -12,32 +12,12 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "1.1.1"
+version = "2.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
+checksum = "ac24f3f660d4c394cc6d24272e526083c257d6045d3be76a9d0a76be5cb56515"
 dependencies = [
  "actix-macros",
- "actix-threadpool",
- "copyless",
- "futures-channel",
- "futures-util",
- "smallvec",
- "tokio 0.2.24",
-]
-
-[[package]]
-name = "actix-threadpool"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d209f04d002854b9afd3743032a27b066158817965bf5d036824d19ac2cc0e30"
-dependencies = [
- "derive_more",
- "futures-channel",
- "lazy_static",
- "log",
- "num_cpus",
- "parking_lot",
- "threadpool",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -180,7 +160,7 @@ dependencies = [
  "polling",
  "vec-arena",
  "waker-fn",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -310,6 +290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,12 +370,6 @@ dependencies = [
  "time",
  "version_check",
 ]
-
-[[package]]
-name = "copyless"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
@@ -471,7 +451,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -487,7 +467,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -508,17 +488,6 @@ dependencies = [
  "num_cpus",
  "serde",
  "tokio 0.3.6",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -601,22 +570,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -779,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -791,7 +744,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.24",
+ "tokio 1.0.1",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -838,18 +791,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "http",
 ]
 
@@ -903,11 +856,11 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -919,7 +872,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.2",
  "socket2",
- "tokio 0.2.24",
+ "tokio 1.0.1",
  "tower-service",
  "tracing",
  "want",
@@ -927,15 +880,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 0.2.24",
- "tokio-tls",
+ "tokio 1.0.1",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -975,15 +928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,7 +939,7 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "crossbeam-utils",
  "curl",
  "curl-sys",
@@ -1027,16 +971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -1143,44 +1077,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
@@ -1208,18 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1231,6 +1135,15 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1316,7 +1229,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1399,7 +1312,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1519,17 +1432,17 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1542,14 +1455,13 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.0",
  "serde",
  "serde_urlencoded",
- "tokio 0.2.24",
- "tokio-tls",
+ "tokio 1.0.1",
+ "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1579,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1740,7 +1652,7 @@ checksum = "97e0e9fd577458a4f61fb91fcb559ea2afecc54c934119421f9f5d3d5b1a1057"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1866,7 +1778,7 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1899,15 +1811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "time"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,7 +1822,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1962,28 +1865,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio",
- "mio-uds",
- "pin-project-lite 0.1.11",
- "signal-hook-registry",
- "slab",
- "tokio-macros",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
@@ -1993,10 +1874,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "0.2.6"
+name = "tokio"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite 0.2.0",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2004,27 +1904,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
+name = "tokio-native-tls"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 0.2.24",
+ "tokio 1.0.1",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.0",
+ "tokio 1.0.1",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
- "tokio 0.2.24",
+ "pin-project-lite 0.2.0",
+ "tokio 1.0.1",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2273,12 +2185,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2286,12 +2192,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2311,7 +2211,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2334,15 +2234,5 @@ dependencies = [
  "serde",
  "serde_json",
  "surf",
- "tokio 0.2.24",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "tokio 1.0.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.4.4-alpha.0"
+version = "0.4.4"
 dependencies = [
  "actix-rt",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ serde = "1"
 regex = "1"
 futures-timer = "3.0.2"
 futures = "0.3.5"
-hyper = "0.13.8"
-tokio = { version = "0.2", features = ["rt-core", "rt-util"] }
+hyper = { version = "0.14", features = ["server"] }
+tokio = { version = "1", features = ["rt", "io-util", "time"] }
 deadpool = "0.6.0"
 async-trait = "0.1.42"
 once_cell = "1.5.2"
@@ -35,7 +35,7 @@ once_cell = "1.5.2"
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 surf = "2"
-reqwest = "0.10.4"
-tokio = { version = "0.2.18", features = ["macros"] }
-actix-rt = "1.1.1"
+reqwest = "0.11"
+tokio = { version = "1", features = ["macros"] }
+actix-rt = "2.0.0-beta.2"
 isahc = "0.9.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiremock"
-version = "0.4.4-alpha.0"
+version = "0.4.4"
 authors = ["Luca Palmieri <rust@lpalmieri.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -184,16 +184,16 @@ Licensed under either of Apache License, Version 2.0 or MIT license at your opti
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
 
-[`MockServer`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.MockServer.html
-[`Mock`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.Mock.html
-[`ResponseTemplate`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.ResponseTemplate
-[`Request`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.Request
-[`Match`]: https://docs.rs/wiremock/0.4.2/wiremock/trait.Match.html
-[`Respond`]: https://docs.rs/wiremock/0.4.2/wiremock/trait.Respond.html
-[`start`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.MockServer.html#method.start
-[`expect`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.Mock.html#method.expect
-[`respond_with`]: https://docs.rs/wiremock/0.4.2/wiremock/struct.MockBuilder.html#method.respond_with
-[`matchers`]: https://docs.rs/wiremock/0.4.2/wiremock/matchers/index.html
+[`MockServer`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.MockServer.html
+[`Mock`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.Mock.html
+[`ResponseTemplate`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.ResponseTemplate
+[`Request`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.Request
+[`Match`]: https://docs.rs/wiremock/0.4.4/wiremock/trait.Match.html
+[`Respond`]: https://docs.rs/wiremock/0.4.4/wiremock/trait.Respond.html
+[`start`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.MockServer.html#method.start
+[`expect`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.Mock.html#method.expect
+[`respond_with`]: https://docs.rs/wiremock/0.4.4/wiremock/struct.MockBuilder.html#method.respond_with
+[`matchers`]: https://docs.rs/wiremock/0.4.4/wiremock/matchers/index.html
 [GitHub repository]: https://github.com/LukeMathWalker/wiremock-rs
 [`mockito`]: https://docs.rs/mockito/
 [`httpmock`]: https://docs.rs/httpmock/

--- a/src/active_mock.rs
+++ b/src/active_mock.rs
@@ -1,11 +1,11 @@
 use crate::{verification::VerificationReport, Match, Mock, Request, ResponseTemplate};
 
-/// Given the behaviour specification as a `Mock`, keep track of runtime information concerning
-/// this mock - e.g. how many times it matched on a incoming request.
+/// Given the behaviour specification as a [`Mock`](crate::Mock), keep track of runtime information
+/// concerning this mock - e.g. how many times it matched on a incoming request.
 pub(crate) struct ActiveMock {
     specification: Mock,
     n_matched_requests: u64,
-    /// The position occupied by this mock within the parent [`MockSet`](crate::mock_set::MockSet)
+    /// The position occupied by this mock within the parent [`ActiveMockSet`](crate::mock_set::ActiveMockSet)
     /// collection of `ActiveMock`s.
     ///
     /// E.g. `0` if this is the first mock that we try to match against an incoming request, `1`

--- a/src/active_mock.rs
+++ b/src/active_mock.rs
@@ -46,7 +46,7 @@ impl ActiveMock {
         VerificationReport {
             mock_name: self.specification.name.clone(),
             n_matched_requests: self.n_matched_requests,
-            expectation_range: self.specification.expectation.range.clone(),
+            expectation_range: self.specification.expectation_range.clone(),
         }
     }
 

--- a/src/active_mock.rs
+++ b/src/active_mock.rs
@@ -44,8 +44,9 @@ impl ActiveMock {
     /// over the number of invocations.
     pub(crate) fn verify(&self) -> VerificationReport {
         VerificationReport {
-            expectation: self.specification.expectation.clone(),
+            mock_name: self.specification.name.clone(),
             n_matched_requests: self.n_matched_requests,
+            expectation_range: self.specification.expectation.range.clone(),
         }
     }
 

--- a/src/active_mock.rs
+++ b/src/active_mock.rs
@@ -5,13 +5,20 @@ use crate::{verification::VerificationReport, Match, Mock, Request, ResponseTemp
 pub(crate) struct ActiveMock {
     specification: Mock,
     n_matched_requests: u64,
+    /// The position occupied by this mock within the parent [`MockSet`](crate::mock_set::MockSet)
+    /// collection of `ActiveMock`s.
+    ///
+    /// E.g. `0` if this is the first mock that we try to match against an incoming request, `1`
+    /// if it is the second, etc.
+    position_in_set: usize,
 }
 
 impl ActiveMock {
-    pub(crate) fn new(specification: Mock) -> Self {
+    pub(crate) fn new(specification: Mock, position_in_set: usize) -> Self {
         Self {
             specification,
             n_matched_requests: 0,
+            position_in_set,
         }
     }
 
@@ -47,6 +54,7 @@ impl ActiveMock {
             mock_name: self.specification.name.clone(),
             n_matched_requests: self.n_matched_requests,
             expectation_range: self.specification.expectation_range.clone(),
+            position_in_set: self.position_in_set,
         }
     }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -214,22 +214,11 @@ pub struct Mock {
     /// If `Some(max_n_matches)`, when `max_n_matches` matching incoming requests have been processed,
     /// [`crate::active_mock::ActiveMock::matches`] should start returning `false`, regardless of the incoming request.
     pub(crate) max_n_matches: Option<u64>,
+    /// The friendly mock name specified by the user.  
+    /// Used in diagnostics and error messages if the mock expectations are not satisfied.
     pub(crate) name: Option<String>,
-    pub(crate) expectation: Expectation,
-}
-
-#[derive(Clone)]
-pub(crate) struct Expectation {
-    /// The expectation is satisfied if the number of incoming requests falls within `range`.
-    pub(crate) range: Times,
-}
-
-impl Default for Expectation {
-    fn default() -> Self {
-        Self {
-            range: Times(TimesEnum::Unbounded(RangeFull)),
-        }
-    }
+    /// The expectation is satisfied if the number of incoming requests falls within `expectation_range`.
+    pub(crate) expectation_range: Times,
 }
 
 /// A fluent builder to construct a [`Mock`] instance given matchers and a [`ResponseTemplate`].
@@ -359,7 +348,7 @@ impl Mock {
     /// ```
     pub fn expect<T: Into<Times>>(mut self, r: T) -> Self {
         let range = r.into();
-        self.expectation = Expectation { range };
+        self.expectation_range = range;
 
         self
     }
@@ -465,7 +454,7 @@ impl MockBuilder {
             response: Box::new(responder),
             max_n_matches: None,
             name: None,
-            expectation: Expectation::default(),
+            expectation_range: Times(TimesEnum::Unbounded(RangeFull)),
         }
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -371,7 +371,7 @@ impl Mock {
     ///
     /// ### Example:
     ///
-    /// ```rust
+    /// ```should_panic
     /// use wiremock::{MockServer, Mock, ResponseTemplate};
     /// use wiremock::matchers::method;
     ///
@@ -400,7 +400,7 @@ impl Mock {
     ///         .expect(1..)
     ///         // We assign a name to the mock - it will be shown in error messages
     ///         // if our expectation is not verified!
-    ///         .named("Root POST ")
+    ///         .named("Root POST")
     ///         .mount(&mock_server)
     ///         .await;
     ///     

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -502,6 +502,20 @@ impl Times {
     }
 }
 
+impl std::fmt::Display for Times {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            TimesEnum::Exact(e) => write!(f, "== {}", e),
+            TimesEnum::Unbounded(_) => write!(f, "0 <= x"),
+            TimesEnum::Range(r) => write!(f, "{} <= x < {}", r.start, r.end),
+            TimesEnum::RangeFrom(r) => write!(f, "{} <= x", r.start),
+            TimesEnum::RangeTo(r) => write!(f, "0 <= x < {}", r.end),
+            TimesEnum::RangeToInclusive(r) => write!(f, "0 <= x <= {}", r.end),
+            TimesEnum::RangeInclusive(r) => write!(f, "{} <= x <= {}", r.start(), r.end()),
+        }
+    }
+}
+
 // Implementation notes: this has gone through a couple of iterations before landing to
 // what you see now.
 //

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -43,12 +43,12 @@ impl BareMockServer {
         std::thread::spawn(move || {
             let server_future = run_server(listener, server_mock_set, shutdown_receiver);
 
-            let mut runtime = tokio::runtime::Builder::new_current_thread()
+            let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("Cannot build local tokio runtime");
 
-            LocalSet::new().block_on(&mut runtime, server_future)
+            LocalSet::new().block_on(&runtime, server_future)
         });
         for _ in 0..40 {
             if TcpStream::connect_timeout(&server_address, std::time::Duration::from_millis(25))

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -43,9 +43,8 @@ impl BareMockServer {
         std::thread::spawn(move || {
             let server_future = run_server(listener, server_mock_set, shutdown_receiver);
 
-            let mut runtime = tokio::runtime::Builder::new()
+            let mut runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
-                .basic_scheduler()
                 .build()
                 .expect("Cannot build local tokio runtime");
 

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -1,5 +1,5 @@
 use crate::mock_server::hyper::run_server;
-use crate::mock_set::MockSet;
+use crate::mock_set::ActiveMockSet;
 use crate::{mock::Mock, verification::VerificationOutcome};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use tokio::task::LocalSet;
 /// is instead a thin facade over a `BareMockServer` retrieved from a pool - see `get_pooled_server`
 /// for more details.
 pub(crate) struct BareMockServer {
-    mock_set: Arc<RwLock<MockSet>>,
+    mock_set: Arc<RwLock<ActiveMockSet>>,
     server_address: SocketAddr,
     // When `_shutdown_trigger` gets dropped the listening server terminates gracefully.
     _shutdown_trigger: tokio::sync::oneshot::Sender<()>,
@@ -34,7 +34,7 @@ impl BareMockServer {
     /// [`TcpListener`](std::net::TcpListener).
     pub(crate) async fn start_on(listener: TcpListener) -> Self {
         let (shutdown_trigger, shutdown_receiver) = tokio::sync::oneshot::channel();
-        let mock_set = Arc::new(RwLock::new(MockSet::new()));
+        let mock_set = Arc::new(RwLock::new(ActiveMockSet::new()));
         let server_address = listener
             .local_addr()
             .expect("Failed to get server address.");

--- a/src/mock_server/hyper.rs
+++ b/src/mock_server/hyper.rs
@@ -1,4 +1,4 @@
-use crate::mock_set::MockSet;
+use crate::mock_set::ActiveMockSet;
 use hyper::http;
 use hyper::service::{make_service_fn, service_fn};
 use std::net::TcpListener;
@@ -9,7 +9,7 @@ type DynError = Box<dyn std::error::Error + Send + Sync>;
 /// The actual HTTP server responding to incoming requests according to the specified mocks.
 pub(crate) async fn run_server(
     listener: TcpListener,
-    mock_set: Arc<RwLock<MockSet>>,
+    mock_set: Arc<RwLock<ActiveMockSet>>,
     shutdown_signal: tokio::sync::oneshot::Receiver<()>,
 ) {
     let request_handler = make_service_fn(move |_| {

--- a/src/mock_set.rs
+++ b/src/mock_set.rs
@@ -7,6 +7,11 @@ use futures_timer::Delay;
 use http_types::{Response, StatusCode};
 use log::debug;
 
+/// The collection of mocks used by a `MockServer` instance to match against
+/// incoming requests.
+///
+/// New mocks are added to `ActiveMockSet` every time [`MockServer::register`](crate::MockServer::register) or
+/// [`Mock::mount`](crate::Mock::mount) are called.
 pub(crate) struct ActiveMockSet {
     mocks: Vec<ActiveMock>,
 }

--- a/src/mock_set.rs
+++ b/src/mock_set.rs
@@ -38,7 +38,9 @@ impl MockSet {
     }
 
     pub(crate) fn register(&mut self, mock: Mock) {
-        self.mocks.push(ActiveMock::new(mock));
+        let n_registered_mocks = self.mocks.len();
+        let active_mock = ActiveMock::new(mock, n_registered_mocks);
+        self.mocks.push(active_mock);
     }
 
     pub(crate) fn reset(&mut self) {

--- a/src/mock_set.rs
+++ b/src/mock_set.rs
@@ -7,14 +7,14 @@ use futures_timer::Delay;
 use http_types::{Response, StatusCode};
 use log::debug;
 
-pub(crate) struct MockSet {
+pub(crate) struct ActiveMockSet {
     mocks: Vec<ActiveMock>,
 }
 
-impl MockSet {
+impl ActiveMockSet {
     /// Create a new instance of MockSet.
-    pub(crate) fn new() -> MockSet {
-        MockSet { mocks: vec![] }
+    pub(crate) fn new() -> ActiveMockSet {
+        ActiveMockSet { mocks: vec![] }
     }
 
     pub(crate) async fn handle_request(&mut self, request: Request) -> Response {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,6 @@
 use futures::AsyncReadExt;
 use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
 use http_types::{Method, Url};
-use hyper::body::Buf;
 use std::{collections::HashMap, fmt};
 
 /// An incoming request to an instance of [`MockServer`].
@@ -87,10 +86,9 @@ impl Request {
             }
         }
 
-        let body = hyper::body::aggregate(body)
+        let body = hyper::body::to_bytes(body)
             .await
             .expect("Failed to read request body.")
-            .bytes()
             .to_vec();
 
         Self {

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -10,6 +10,12 @@ pub(crate) struct VerificationReport {
     pub(crate) expectation_range: Times,
     /// Actual number of received requests that matched the specification
     pub(crate) n_matched_requests: u64,
+    /// The position occupied by the mock that generated the report within its parent
+    /// [`MockSet`](crate::mock_set::MockSet) collection of `ActiveMock`s.
+    ///
+    /// E.g. `0` if it is the first mock that we try to match against an incoming request, `1`
+    /// if it is the second, etc.
+    pub(crate) position_in_set: usize,
 }
 
 impl VerificationReport {
@@ -21,8 +27,8 @@ impl VerificationReport {
             )
         } else {
             format!(
-                "Expected range of matching incoming requests: {:?}, actual: {}",
-                self.expectation_range, self.n_matched_requests
+                "Mock #{}. Expected range of matching incoming requests: {:?}, actual: {}",
+                self.position_in_set, self.expectation_range, self.n_matched_requests
             )
         }
     }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -22,12 +22,12 @@ impl VerificationReport {
     pub(crate) fn error_message(&self) -> String {
         if let Some(ref mock_name) = self.mock_name {
             format!(
-                "{}. Expected range of matching incoming requests: {:?}, actual: {}",
+                "{}.\n\tExpected range of matching incoming requests: {}\n\tNumber of matched incoming requests: {}",
                 mock_name, self.expectation_range, self.n_matched_requests
             )
         } else {
             format!(
-                "Mock #{}. Expected range of matching incoming requests: {:?}, actual: {}",
+                "Mock #{}.\n\tExpected range of matching incoming requests: {}\n\tNumber of matched incoming requests: {}",
                 self.position_in_set, self.expectation_range, self.n_matched_requests
             )
         }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -11,7 +11,7 @@ pub(crate) struct VerificationReport {
     /// Actual number of received requests that matched the specification
     pub(crate) n_matched_requests: u64,
     /// The position occupied by the mock that generated the report within its parent
-    /// [`MockSet`](crate::mock_set::MockSet) collection of `ActiveMock`s.
+    /// [`ActiveMockSet`](crate::mock_set::ActiveMockSet) collection of `ActiveMock`s.
     ///
     /// E.g. `0` if it is the first mock that we try to match against an incoming request, `1`
     /// if it is the second, etc.

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1,25 +1,34 @@
-use crate::mock::Expectation;
+use crate::mock::Times;
 
 /// A report returned by an `ActiveMock` detailing what the user expectations were and
 /// how many calls were actually received since the mock was mounted on the server.
 #[derive(Clone)]
 pub(crate) struct VerificationReport {
+    /// The mock name specified by the user.
+    pub(crate) mock_name: Option<String>,
     /// What users specified
-    pub(crate) expectation: Expectation,
+    pub(crate) expectation_range: Times,
     /// Actual number of received requests that matched the specification
     pub(crate) n_matched_requests: u64,
 }
 
 impl VerificationReport {
     pub(crate) fn error_message(&self) -> String {
-        format!(
-            "{}. Expected range of matching incoming requests: {:?}, actual: {}",
-            self.expectation.error_message, self.expectation.range, self.n_matched_requests
-        )
+        if let Some(ref mock_name) = self.mock_name {
+            format!(
+                "{}. Expected range of matching incoming requests: {:?}, actual: {}",
+                mock_name, self.expectation_range, self.n_matched_requests
+            )
+        } else {
+            format!(
+                "Expected range of matching incoming requests: {:?}, actual: {}",
+                self.expectation_range, self.n_matched_requests
+            )
+        }
     }
 
     pub(crate) fn is_satisfied(&self) -> bool {
-        self.expectation.range.contains(self.n_matched_requests)
+        self.expectation_range.contains(self.n_matched_requests)
     }
 }
 

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -31,10 +31,8 @@ async fn panics_if_the_expectation_is_not_satisfied() {
     let response = ResponseTemplate::new(200);
     Mock::given(method("GET"))
         .respond_with(response)
-        .expect(
-            1..,
-            "panics_if_the_expectation_is_not_satisfied expectation failed",
-        )
+        .expect(1..)
+        .named("panics_if_the_expectation_is_not_satisfied expectation failed")
         .mount(&mock_server)
         .await;
 
@@ -49,10 +47,8 @@ async fn panic_during_expectation_does_not_crash() {
     let response = ResponseTemplate::new(200);
     Mock::given(method("GET"))
         .respond_with(response)
-        .expect(
-            1..,
-            "panic_during_expectation_does_not_crash expectation failed",
-        )
+        .expect(1..)
+        .named("panic_during_expectation_does_not_crash expectation failed")
         .mount(&mock_server)
         .await;
 
@@ -90,6 +86,7 @@ async fn two_route_mocks() {
     Mock::given(method("GET"))
         .and(PathExactMatcher::new("first"))
         .respond_with(response)
+        .named("/first")
         .mount(&mock_server)
         .await;
 
@@ -98,6 +95,7 @@ async fn two_route_mocks() {
     Mock::given(method("GET"))
         .and(PathExactMatcher::new("second"))
         .respond_with(response)
+        .named("/second")
         .mount(&mock_server)
         .await;
 


### PR DESCRIPTION
Reworks #40 by @MarcoIeni to make it a backwards-compatible change.
It cuts a new release - `0.4.4`.

Other changes that do not impact the public API:
- adds a `Display` implementation for `Times`
- falls back to the mock number if no name has been specified by the user (e.g. `Mock #1` failed);
- rename `MockSet` to `ActiveMockSet`,
- upgrade tokio, reqwest and hyper to their latest releases.

Closes #45 
Closes #46