### PR TITLE
feat: support multi values request headers

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,9 @@
+use std::str::FromStr;
+use std::{collections::HashMap, fmt};
+
 use futures::AsyncReadExt;
 use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
 use http_types::{Method, Url};
-use std::{collections::HashMap, fmt};
 
 /// An incoming request to an instance of [`MockServer`].
 ///
@@ -83,12 +85,16 @@ impl Request {
 
         let mut headers = HashMap::new();
         for (name, value) in parts.headers {
-            let value = value.as_bytes().to_owned();
-            let value = HeaderValue::from_bytes(value).unwrap();
             if let Some(name) = name {
                 let name = name.as_str().as_bytes().to_owned();
                 let name = HeaderName::from_bytes(name).unwrap();
-                headers.insert(name, value.into());
+                let value = value.as_bytes().to_owned();
+                let value = HeaderValue::from_bytes(value).unwrap();
+                let value_parts = value.as_str().split(',');
+                let value_parts = value_parts
+                    .map(|it| it.trim())
+                    .filter_map(|it| HeaderValue::from_str(it).ok());
+                headers.insert(name, value_parts.collect());
             }
         }
 

--- a/tests/request_header_matching.rs
+++ b/tests/request_header_matching.rs
@@ -1,0 +1,116 @@
+use wiremock::matchers::{header, headers, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[async_std::test]
+async fn should_match_simple_request_header() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("GET"))
+        .and(header("content-type", "application/json"))
+        .respond_with(ResponseTemplate::new(200));
+    mock_server.register(mock).await;
+
+    // Act
+    let should_match = surf::get(mock_server.uri())
+        .header("content-type", "application/json")
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_match.status(), 200);
+}
+
+#[async_std::test]
+async fn should_not_match_simple_request_header_upon_wrong_key() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("GET"))
+        .and(header("content-type", "application/json"))
+        .respond_with(ResponseTemplate::new(200));
+    mock_server.register(mock).await;
+
+    // Act
+    let should_fail_wrong_key = surf::get(mock_server.uri())
+        .header("accept", "application/json")
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_fail_wrong_key.status(), 404);
+}
+
+#[async_std::test]
+async fn should_not_match_simple_request_header_upon_wrong_value() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("GET"))
+        .and(header("content-type", "application/json"))
+        .respond_with(ResponseTemplate::new(200));
+    mock_server.register(mock).await;
+
+    // Act
+    let should_fail_wrong_value = surf::get(mock_server.uri())
+        .header("content-type", "application/xml")
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_fail_wrong_value.status(), 404);
+}
+
+#[async_std::test]
+async fn should_match_multi_request_header() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let header_matcher = headers("cache-control", vec!["no-cache", "no-store"]);
+    let mock = Mock::given(method("GET"))
+        .and(header_matcher)
+        .respond_with(ResponseTemplate::new(200));
+    mock_server.register(mock).await;
+
+    // Act
+    let should_match = surf::get(mock_server.uri())
+        .header("cache-control", "no-cache, no-store")
+        .await
+        .unwrap();
+
+    // Assert
+    assert_eq!(should_match.status(), 200);
+}
+
+#[async_std::test]
+async fn should_not_match_multi_request_header_upon_wrong_values() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let header_matcher = headers("cache-control", vec!["no-cache", "no-store"]);
+    let mock = Mock::given(method("GET"))
+        .and(header_matcher)
+        .respond_with(ResponseTemplate::new(200));
+    mock_server.register(mock).await;
+
+    // Act
+    let should_fail_wrong_values = surf::get(mock_server.uri())
+        .header("cache-control", "no-cache, no-transform")
+        .await
+        .unwrap();
+
+    // Assert
+    assert_eq!(should_fail_wrong_values.status(), 404);
+}
+
+#[async_std::test]
+async fn should_not_match_multi_request_header_upon_incomplete_values() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let header_matcher = headers("cache-control", vec!["no-cache", "no-store"]);
+    let mock = Mock::given(method("GET"))
+        .and(header_matcher)
+        .respond_with(ResponseTemplate::new(200));
+    mock_server.register(mock).await;
+
+    // Act
+    let should_fail_incomplete_values = surf::get(mock_server.uri())
+        .header("cache-control", "no-cache")
+        .await
+        .unwrap();
+
+    // Assert
+    assert_eq!(should_fail_incomplete_values.status(), 404);
+}


### PR DESCRIPTION
support multi values request headers.  
Fixes wiremock::Request conversion from hyper::Request was not converting comma separated header values into HeaderValues. Introduced 'headers' to create an exact header matcher for multi values headers.