### PR TITLE
Remove textwrap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,12 +1718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "smawk"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
-
-[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,16 +1852,6 @@ dependencies = [
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89bc85084ac4e273c6bbf99050d932821af166392aaedc5038a38e1f229cdf5"
-dependencies = [
- "smawk",
- "unicode-width",
 ]
 
 [[package]]
@@ -2107,12 +2091,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2303,5 @@ dependencies = [
  "serde",
  "serde_json",
  "surf",
- "textwrap",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { version = "1", features = ["rt", "io-util", "time"] }
 deadpool = "0.7.0"
 async-trait = "0.1.42"
 once_cell = "1.5.2"
-textwrap = "0.13.3"
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -135,7 +135,7 @@ impl MockServer {
     ///
     ///     // We won't register this mock instead.
     ///     let unregistered_mock = Mock::given(method("GET")).respond_with(response);
-    ///     
+    ///
     ///     // Act
     ///     let status = surf::get(&mock_server.uri())
     ///         .await
@@ -156,7 +156,7 @@ impl MockServer {
         self.0.register(mock).await
     }
 
-    /// Drop all mounted [`Mock`]s from an instance of [`MockServer`].  
+    /// Drop all mounted [`Mock`]s from an instance of [`MockServer`].
     /// It also deletes all recorded requests.
     ///
     /// ### Example
@@ -172,7 +172,7 @@ impl MockServer {
     ///
     ///     let response = ResponseTemplate::new(200);
     ///     Mock::given(method("GET")).respond_with(response).mount(&mock_server).await;
-    ///     
+    ///
     ///     // Act
     ///     let status = surf::get(&mock_server.uri())
     ///         .await
@@ -202,7 +202,7 @@ impl MockServer {
     /// async fn main() {
     ///     // Arrange
     ///     let mock_server = MockServer::start().await;
-    ///     
+    ///
     ///     // Act
     ///     surf::get(&mock_server.uri()).await.unwrap();
     ///
@@ -315,7 +315,7 @@ impl MockServer {
         self.0.address()
     }
 
-    /// Return a vector with all the requests received by the `MockServer` since it started.  
+    /// Return a vector with all the requests received by the `MockServer` since it started.
     /// If no request has been served, it returns an empty vector.
     ///
     /// If request recording has been disabled using [`MockServerBuilder::disable_request_recording`],
@@ -331,7 +331,7 @@ impl MockServer {
     /// async fn main() {
     ///     // Arrange
     ///     let mock_server = MockServer::start().await;
-    ///     
+    ///
     ///     // Act
     ///     surf::get(&mock_server.uri()).await.unwrap();
     ///
@@ -355,7 +355,7 @@ impl MockServer {
     /// async fn main() {
     ///     // Arrange
     ///     let mock_server = MockServer::start().await;
-    ///     
+    ///
     ///     // Assert
     ///     let received_requests = mock_server.received_requests().await.unwrap();
     ///     assert_eq!(received_requests.len(), 0);
@@ -371,7 +371,7 @@ impl MockServer {
     /// async fn main() {
     ///     // Arrange
     ///     let mock_server = MockServer::builder().disable_request_recording().start().await;
-    ///     
+    ///
     ///     // Assert
     ///     let received_requests = mock_server.received_requests().await;
     ///     assert!(received_requests.is_none());

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -239,11 +239,7 @@ impl MockServer {
                             .into_iter()
                             .enumerate()
                             .map(|(index, request)| {
-                                format!(
-                                    "- Request #{}\n{}",
-                                    index + 1,
-                                    textwrap::indent(&format!("{}", request), "\t")
-                                )
+                                format!("- Request #{}\n{}", index + 1, &format!("\t{}", request))
                             })
                             .collect::<String>()
                     )


### PR DESCRIPTION
hi-oh (again)

I'm curious about this `textwrap` crate. I've only spotted one point where it is used, I've tried removing it and run a test to compare the output: they look identical.

I'm cautious about this change as I still may miss why you're using this crate, what do you think?

thanks