### PR TITLE
request: Fix URI conversion when authority part is present

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -75,10 +75,9 @@ impl Request {
     pub(crate) async fn from_hyper(request: hyper::Request<hyper::Body>) -> Request {
         let (parts, body) = request.into_parts();
         let method = parts.method.into();
-        let url = if let Some(port) = parts.uri.port_u16() {
-            format!("http://localhost:{}{}", port, parts.uri)
-        } else {
-            format!("http://localhost{}", parts.uri)
+        let url = match parts.uri.authority() {
+            Some(_) => parts.uri.to_string(),
+            None => format!("http://localhost{}", parts.uri),
         }
         .parse()
         .unwrap();


### PR DESCRIPTION
This fixes a panic that happened when the incoming request sets the full path with authority (e.g. when using Tonic). The then-formatted URI was incorrect, leading to ParseErrors, which turned into panics.

Testing for the port is enough to determine whether the incoming request has the authority part set, however it does not uses it correctly: it formats the URI to parse as "http://localhost:{port}{uri}" which is incorrect, since `uri` _already_ contains `localhost:{port}`, resulting in completely bogus URIs like `http://localhost:33593http://localhost:33593/grpc.examples.echo/UnaryEcho`.

This completely removes the formatting in case the authority is present, and simply stringifies the incoming URI.