### PR TITLE
re-export http_types::headers::HeaderName

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,3 +159,4 @@ pub use mock_server::{MockServer, MockServerBuilder};
 pub use request::Request;
 pub use respond::Respond;
 pub use response_template::ResponseTemplate;
+pub use http_types::headers::HeaderName;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,4 +159,4 @@ pub use mock_server::{MockServer, MockServerBuilder};
 pub use request::Request;
 pub use respond::Respond;
 pub use response_template::ResponseTemplate;
-pub use http_types::headers::HeaderName;
+pub use http_types::headers::{HeaderName, HeaderValue};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,4 +159,4 @@ pub use mock_server::{MockServer, MockServerBuilder};
 pub use request::Request;
 pub use respond::Respond;
 pub use response_template::ResponseTemplate;
-pub use http_types::headers::{HeaderName, HeaderValue};
+pub use http_types::headers::{HeaderName, HeaderValue, HeaderValues};


### PR DESCRIPTION
The `Request`s:

```rs
pub headers: HashMap<HeaderName, HeaderValues>,
```

is public while `HeaderName` is private, making it impossible to actually `.get()` something