### PR TITLE
add 'with_priority()' to handle interlaced request matching conditions

### DIFF
--- a/src/mock_set.rs
+++ b/src/mock_set.rs
@@ -48,6 +48,8 @@ impl MountedMockSet {
     pub(crate) async fn handle_request(&mut self, request: Request) -> (Response, Option<Delay>) {
         debug!("Handling request.");
         let mut response_template: Option<ResponseTemplate> = None;
+        self.mocks
+            .sort_by_key(|(m, _)| m.specification.priority);
         for (mock, mock_state) in &mut self.mocks {
             if *mock_state == MountedMockState::OutOfScope {
                 continue;

--- a/src/mounted_mock.rs
+++ b/src/mounted_mock.rs
@@ -3,7 +3,7 @@ use crate::{verification::VerificationReport, Match, Mock, Request, ResponseTemp
 /// Given the behaviour specification as a [`Mock`](crate::Mock), keep track of runtime information
 /// concerning this mock - e.g. how many times it matched on a incoming request.
 pub(crate) struct MountedMock {
-    specification: Mock,
+    pub(crate) specification: Mock,
     n_matched_requests: u64,
     /// The position occupied by this mock within the parent [`MountedMockSet`](crate::mock_set::MountedMockSet)
     /// collection of `MountedMock`s.

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -1,0 +1,89 @@
+use wiremock::{
+    matchers::{method, path, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[async_std::test]
+async fn should_prioritize_mock_with_highest_priority() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let exact = Mock::given(method("GET"))
+        .and(path("abcd"))
+        .respond_with(ResponseTemplate::new(200))
+        .with_priority(2);
+    mock_server.register(exact).await;
+    let regex = Mock::given(method("GET"))
+        .and(path_regex("[a-z]{4}"))
+        .respond_with(ResponseTemplate::new(201))
+        .with_priority(1);
+    mock_server.register(regex).await;
+
+    // Act
+    let should_match = surf::get(format!("{}/abcd", mock_server.uri()))
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_match.status(), 201);
+}
+
+#[async_std::test]
+async fn should_not_prioritize_mock_with_lower_priority() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let exact = Mock::given(method("GET"))
+        .and(path("abcd"))
+        .respond_with(ResponseTemplate::new(200))
+        .with_priority(u8::MAX);
+    mock_server.register(exact).await;
+    let regex = Mock::given(method("GET"))
+        .and(path_regex("[a-z]{4}"))
+        .respond_with(ResponseTemplate::new(201));
+    mock_server.register(regex).await;
+
+    // Act
+    let should_match = surf::get(format!("{}/abcd", mock_server.uri()))
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_match.status(), 201);
+}
+
+#[async_std::test]
+async fn by_default_should_use_insertion_order() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let exact = Mock::given(method("GET"))
+        .and(path("abcd"))
+        .respond_with(ResponseTemplate::new(200));
+    let regex = Mock::given(method("GET"))
+        .and(path_regex("[a-z]{4}"))
+        .respond_with(ResponseTemplate::new(201));
+    mock_server.register(exact).await;
+    mock_server.register(regex).await;
+
+    // Act
+    let should_match = surf::get(format!("{}/abcd", mock_server.uri()))
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_match.status(), 200);
+
+    // Insert mocks in the opposite order
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let exact = Mock::given(method("GET"))
+        .and(path("abcd"))
+        .respond_with(ResponseTemplate::new(200));
+    let regex = Mock::given(method("GET"))
+        .and(path_regex("[a-z]{4}"))
+        .respond_with(ResponseTemplate::new(201));
+    mock_server.register(regex).await;
+    mock_server.register(exact).await;
+
+    // Act
+    let should_match = surf::get(format!("{}/abcd", mock_server.uri()))
+        .await
+        .unwrap();
+    // Assert
+    assert_eq!(should_match.status(), 201);
+}


### PR DESCRIPTION
Hi @LukeMathWalker,
this is something from the original Wiremock I wanted to bring in wiremock-rs for a long time.  
Let me know what you think