### PR TITLE
add method for matching headers with a Regex

### DIFF
--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -446,7 +446,7 @@ impl Match for HeaderExistsMatcher {
 }
 
 #[derive(Debug)]
-/// Match the value of a specific header of a request against a regular expression.
+/// Match the value of a header using a regular expression.
 /// All header values received for a header name must match, and at least one must be provided.
 ///
 /// ### Example:

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -460,7 +460,7 @@ impl Match for HeaderExistsMatcher {
 ///     // Arrange
 ///     let mock_server = MockServer::start().await;
 ///
-///     Mock::given(header_regex("custom", r"header"))
+///     Mock::given(header_regex("custom", "header"))
 ///         .respond_with(ResponseTemplate::new(200))
 ///         .mount(&mock_server)
 ///         .await;

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -447,7 +447,8 @@ impl Match for HeaderExistsMatcher {
 
 #[derive(Debug)]
 /// Match the value of a header using a regular expression.
-/// All header values received for a header name must match, and at least one must be provided.
+/// If the header is multi-valued, all values must satisfy the regular expression. 
+/// If the header is missing, the mock will not match.
 ///
 /// ### Example:
 /// ```rust

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -12,7 +12,7 @@ use assert_json_diff::{assert_json_matches_no_panic, CompareMode};
 use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
 use http_types::Method;
 use log::debug;
-use regex::{Regex, RegexSet};
+use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
 use std::convert::TryInto;
@@ -446,7 +446,7 @@ impl Match for HeaderExistsMatcher {
 }
 
 #[derive(Debug)]
-/// Match the value of a specific header of a request against a regular expression set.
+/// Match the value of a specific header of a request against a regular expression.
 /// All header values received for a header name must match, and at least one must be provided.
 ///
 /// ### Example:
@@ -459,7 +459,7 @@ impl Match for HeaderExistsMatcher {
 ///     // Arrange
 ///     let mock_server = MockServer::start().await;
 ///
-///     Mock::given(header_regex("custom", &[r"header"]))
+///     Mock::given(header_regex("custom", r"header"))
 ///         .respond_with(ResponseTemplate::new(200))
 ///         .mount(&mock_server)
 ///         .await;
@@ -475,10 +475,10 @@ impl Match for HeaderExistsMatcher {
 ///     assert_eq!(status, 200);
 /// }
 /// ```
-pub struct HeaderRegexMatcher(HeaderName, RegexSet);
+pub struct HeaderRegexMatcher(HeaderName, Regex);
 
 /// Shorthand for [`HeaderRegexMatcher::new`].
-pub fn header_regex<K>(key: K, value: &[&str]) -> HeaderRegexMatcher
+pub fn header_regex<K>(key: K, value: &str) -> HeaderRegexMatcher
 where
     K: TryInto<HeaderName>,
     <K as TryInto<HeaderName>>::Error: std::fmt::Debug,
@@ -487,13 +487,13 @@ where
 }
 
 impl HeaderRegexMatcher {
-    pub fn new<K>(key: K, value: &[&str]) -> Self
+    pub fn new<K>(key: K, value: &str) -> Self
     where
         K: TryInto<HeaderName>,
         <K as TryInto<HeaderName>>::Error: std::fmt::Debug,
     {
         let key = key.try_into().expect("Failed to convert to header name.");
-        let value_matcher = RegexSet::new(value).expect("Failed to create regex for value matcher");
+        let value_matcher = Regex::new(value).expect("Failed to create regex for value matcher");
         Self(key, value_matcher)
     }
 }

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -12,7 +12,7 @@ use assert_json_diff::{assert_json_matches_no_panic, CompareMode};
 use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
 use http_types::Method;
 use log::debug;
-use regex::Regex;
+use regex::{Regex, RegexSet};
 use serde::Serialize;
 use serde_json::Value;
 use std::convert::TryInto;
@@ -442,6 +442,71 @@ impl HeaderExistsMatcher {
 impl Match for HeaderExistsMatcher {
     fn matches(&self, request: &Request) -> bool {
         request.headers.get(&self.0).is_some()
+    }
+}
+
+#[derive(Debug)]
+/// Match the value of a specific header of a request against a regular expression set.
+/// All header values received for a header name must match, and at least one must be provided.
+///
+/// ### Example:
+/// ```rust
+/// use wiremock::{MockServer, Mock, ResponseTemplate};
+/// use wiremock::matchers::header_regex;
+///
+/// #[async_std::main]
+/// async fn main() {
+///     // Arrange
+///     let mock_server = MockServer::start().await;
+///
+///     Mock::given(header_regex("custom", &[r"header"]))
+///         .respond_with(ResponseTemplate::new(200))
+///         .mount(&mock_server)
+///         .await;
+///
+///     // Act
+///     let status = surf::get(&mock_server.uri())
+///         .header("custom", "headers are fun to match on with a regex")
+///         .await
+///         .unwrap()
+///         .status();
+///
+///     // Assert
+///     assert_eq!(status, 200);
+/// }
+/// ```
+pub struct HeaderRegexMatcher(HeaderName, RegexSet);
+
+/// Shorthand for [`HeaderRegexMatcher::new`].
+pub fn header_regex<K>(key: K, value: &[&str]) -> HeaderRegexMatcher
+where
+    K: TryInto<HeaderName>,
+    <K as TryInto<HeaderName>>::Error: std::fmt::Debug,
+{
+    HeaderRegexMatcher::new(key, value)
+}
+
+impl HeaderRegexMatcher {
+    pub fn new<K>(key: K, value: &[&str]) -> Self
+    where
+        K: TryInto<HeaderName>,
+        <K as TryInto<HeaderName>>::Error: std::fmt::Debug,
+    {
+        let key = key.try_into().expect("Failed to convert to header name.");
+        let value_matcher = RegexSet::new(value).expect("Failed to create regex for value matcher");
+        Self(key, value_matcher)
+    }
+}
+
+impl Match for HeaderRegexMatcher {
+    fn matches(&self, request: &Request) -> bool {
+        match request.headers.get(&self.0) {
+            None => false,
+            Some(values) => {
+                let has_values = values.iter().next().is_some();
+                has_values && values.iter().all(|v| self.1.is_match(v.as_str()))
+            }
+        }
     }
 }
 

--- a/tests/request_header_matching.rs
+++ b/tests/request_header_matching.rs
@@ -120,7 +120,7 @@ async fn should_match_regex_single_header_value() {
     // Arrange
     let mock_server = MockServer::start().await;
     let mock = Mock::given(method("GET"))
-        .and(header_regex("cache-control", &[r"no-(cache|store)"]))
+        .and(header_regex("cache-control", r"no-(cache|store)"))
         .respond_with(ResponseTemplate::new(200));
     mock_server.register(mock).await;
 
@@ -139,7 +139,7 @@ async fn should_match_regex_multiple_header_values() {
     // Arrange
     let mock_server = MockServer::start().await;
     let mock = Mock::given(method("GET"))
-        .and(header_regex("cache-control", &[r"no-(cache|store)"]))
+        .and(header_regex("cache-control", r"no-(cache|store)"))
         .respond_with(ResponseTemplate::new(200));
     mock_server.register(mock).await;
 
@@ -159,7 +159,7 @@ async fn should_not_match_regex_with_wrong_header_value() {
     // Arrange
     let mock_server = MockServer::start().await;
     let mock = Mock::given(method("GET"))
-        .and(header_regex("cache-control", &[r"no-(cache|store)"]))
+        .and(header_regex("cache-control", r"no-(cache|store)"))
         .respond_with(ResponseTemplate::new(200));
     mock_server.register(mock).await;
 
@@ -178,7 +178,7 @@ async fn should_not_match_regex_with_at_least_one_wrong_header_value() {
     // Arrange
     let mock_server = MockServer::start().await;
     let mock = Mock::given(method("GET"))
-        .and(header_regex("cache-control", &[r"no-(cache|store)"]))
+        .and(header_regex("cache-control", r"no-(cache|store)"))
         .respond_with(ResponseTemplate::new(200));
     mock_server.register(mock).await;
 
@@ -198,7 +198,7 @@ async fn should_not_match_regex_with_no_values_for_header() {
     // Arrange
     let mock_server = MockServer::start().await;
     let mock = Mock::given(method("GET"))
-        .and(header_regex("cache-control", &[r"no-(cache|store)"]))
+        .and(header_regex("cache-control", r"no-(cache|store)"))
         .respond_with(ResponseTemplate::new(200));
     mock_server.register(mock).await;
 


### PR DESCRIPTION
Sometimes it's useful to be able to match a header based on a pattern, rather than having to specify a static string value.  Mockito implements this via `.match_header("name", Matcher::Regex(...))`.  This goes one step further, leveraging RegexSet.