### PR TITLE
Add matchers for Basic and Bearer Authorization types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,16 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,14 +821,13 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "6.3.5"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5566ecc26bc6b04e773e680d66141fced78e091ad818e420d726c152b05a64ff"
+checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
 dependencies = [
  "async-std",
  "async-trait",
  "cfg-if 1.0.0",
- "dashmap",
  "http-types",
  "isahc 0.9.14",
  "log",
@@ -1798,15 +1787,16 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "surf"
-version = "2.2.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a154d33ca6b5e1fe6fd1c760e5a5cc1202425f6cca2e13229f16a69009f6328"
+checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
 dependencies = [
  "async-std",
  "async-trait",
  "cfg-if 1.0.0",
  "encoding_rs",
  "futures-util",
+ "getrandom 0.2.1",
  "http-client",
  "http-types",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ dependencies = [
  "assert-json-diff",
  "async-std",
  "async-trait",
+ "base64 0.13.0",
  "deadpool",
  "futures",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ base64 = "0.13.0"
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
-surf = "2.2.0"
+surf = "2.3.2"
 reqwest = "0.11.3"
 tokio = { version = "1.5.0", features = ["macros"] }
 actix-rt = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ deadpool = "0.9.2"
 async-trait = "0.1"
 once_cell = "1"
 assert-json-diff = "2.0.1"
+base64 = "0.13.0"
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -975,9 +975,48 @@ where
 }
 
 #[derive(Debug)]
+/// Match an incoming request if it contains the basic authentication header with the username and password
+/// as per [RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617).
+///
+/// ### Example:
+/// ```rust
+/// use wiremock::{MockServer, Mock, ResponseTemplate};
+/// use wiremock::matchers::basic_auth;
+/// use serde::{Deserialize, Serialize};
+/// use http_types::auth::BasicAuth;
+/// use std::convert::TryInto;
+///
+/// #[async_std::main]
+/// async fn main() {
+///     // Arrange
+///     let mock_server = MockServer::start().await;
+///
+///
+///     Mock::given(basic_auth("username", "password"))
+///         .respond_with(ResponseTemplate::new(200))
+///         .mount(&mock_server)
+///         .await;
+///         
+///     let auth = BasicAuth::new("username", "password");
+///     let client: surf::Client = surf::Config::new()
+///         .set_base_url(surf::Url::parse(&mock_server.uri()).unwrap())
+///         .add_header(auth.name(), auth.value()).unwrap()
+///         .try_into().unwrap();
+///
+///     // Act
+///     let status = client.get("/")
+///         .await
+///         .unwrap()
+///         .status();
+///     
+///     // Assert
+///     assert_eq!(status, 200);
+/// }
+/// ```
 pub struct BasicAuthMatcher(HeaderExactMatcher);
 
 impl BasicAuthMatcher {
+    /// Match basic authentication header using the given username and password.
     pub fn from_credentials(username: impl AsRef<str>, password: impl AsRef<str>) -> Self {
         Self::from_token(base64::encode(format!(
             "{}:{}",
@@ -986,6 +1025,7 @@ impl BasicAuthMatcher {
         )))
     }
 
+    /// Match basic authentication header with the exact token given.
     pub fn from_token(token: impl AsRef<str>) -> Self {
         Self(header(
             "Authorization",
@@ -994,6 +1034,7 @@ impl BasicAuthMatcher {
     }
 }
 
+/// Shorthand for [`BasicAuthMatcher::from_credentials`].
 pub fn basic_auth<U, P>(username: U, password: P) -> BasicAuthMatcher
 where
     U: AsRef<str>,
@@ -1009,6 +1050,37 @@ impl Match for BasicAuthMatcher {
 }
 
 #[derive(Debug)]
+/// Match an incoming request if it contains the bearer token header
+/// as per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750).
+///
+/// ### Example:
+/// ```rust
+/// use wiremock::{MockServer, Mock, ResponseTemplate};
+/// use wiremock::matchers::bearer_token;
+/// use serde::{Deserialize, Serialize};
+/// use http_types::auth::BasicAuth;
+///
+/// #[async_std::main]
+/// async fn main() {
+///     // Arrange
+///     let mock_server = MockServer::start().await;
+///
+///     Mock::given(bearer_token("token"))
+///         .respond_with(ResponseTemplate::new(200))
+///         .mount(&mock_server)
+///         .await;
+///
+///     // Act
+///     let status = surf::get(&mock_server.uri())
+///         .header("Authorization", "Bearer token")
+///         .await
+///         .unwrap()
+///         .status();
+///     
+///     // Assert
+///     assert_eq!(status, 200);
+/// }
+/// ```
 pub struct BearerTokenMatcher(HeaderExactMatcher);
 
 impl BearerTokenMatcher {
@@ -1026,6 +1098,7 @@ impl Match for BearerTokenMatcher {
     }
 }
 
+/// Shorthand for [`BearerTokenMatcher::from_token`].
 pub fn bearer_token<T>(token: T) -> BearerTokenMatcher
 where
     T: AsRef<str>,


### PR DESCRIPTION
This adds support for matching Basic and Bearer auth types, as I find myself
reaching for that occasionally and would like to support it in this library as
well. Additionally, basicAuth at least is supported in the existing Wiremock in
Java, so I feel it's not fully philosophically distant.

I've omitted documentation and doctests for now. If the general implementation
is okay I'll write up something nice.
