### PR TITLE
README: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add `wiremock` to your development dependencies by editing the `Cargo.toml` file
 # ...
 wiremock = "0.5"
 ```
-or by running:
+Or by running:
 ```bash
 cargo add wiremock --dev
 ```

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ It provides mocking of HTTP responses using request matching and response templa
 
 ## How to install
 
-Add `wiremock` to your development dependencies:
+Add `wiremock` to your development dependencies by editing the `Cargo.toml` file:
 ```toml
 [dev-dependencies]
 # ...
 wiremock = "0.5"
 ```
-If you are using [`cargo-edit`](https://github.com/killercup/cargo-edit), run
+or by running:
 ```bash
 cargo add wiremock --dev
 ```


### PR DESCRIPTION
`cargo add` is now integrated in cargo. So there's no need to install `cargo-edit`.