### PR TITLE
Use MockGuards to expose matched requetsts on mocks

### DIFF
--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -184,6 +184,14 @@ pub struct MockGuard {
     server_state: Arc<RwLock<MockServerState>>,
 }
 
+impl MockGuard {
+    pub async fn received_requests(&self) -> Vec<crate::Request> {
+        let state = self.server_state.read().await;
+        let (mounted_mock, _) = &state.mock_set[self.mock_id];
+        mounted_mock.received_requests()
+    }
+}
+
 impl Drop for MockGuard {
     fn drop(&mut self) {
         let future = async move {

--- a/src/mounted_mock.rs
+++ b/src/mounted_mock.rs
@@ -11,6 +11,9 @@ pub(crate) struct MountedMock {
     /// E.g. `0` if this is the first mock that we try to match against an incoming request, `1`
     /// if it is the second, etc.
     position_in_set: usize,
+
+    // matched requests:
+    matched_requests: Vec<crate::Request>,
 }
 
 impl MountedMock {
@@ -19,6 +22,7 @@ impl MountedMock {
             specification,
             n_matched_requests: 0,
             position_in_set,
+            matched_requests: Vec::new(),
         }
     }
 
@@ -41,6 +45,8 @@ impl MountedMock {
             if matched {
                 // Increase match count
                 self.n_matched_requests += 1;
+                // Keep track of request
+                self.matched_requests.push(request.clone())
             }
 
             matched
@@ -60,5 +66,9 @@ impl MountedMock {
 
     pub(crate) fn response_template(&self, request: &Request) -> ResponseTemplate {
         self.specification.response_template(request)
+    }
+
+    pub(crate) fn received_requests(&self) -> Vec<crate::Request> {
+        self.matched_requests.clone()
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::{collections::HashMap, fmt};
 
 use futures::AsyncReadExt;
+use http_types::convert::DeserializeOwned;
 use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
 use http_types::{Method, Url};
 
@@ -47,6 +48,10 @@ impl fmt::Display for Request {
 }
 
 impl Request {
+    pub fn body_json<T: DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(&self.body)
+    }
+
     pub async fn from(mut request: http_types::Request) -> Request {
         let method = request.method();
         let url = request.url().to_owned();


### PR DESCRIPTION
The current way to interact with wiremock is to setup mocks with expectations (on bodys, headers, paths, etc)
and then verify these when the server is dropped.
This PR tries to sketch out an alternative interaction model, where mocks capture the requests they matched
and then expose them to users for verification.
This should help in separating "mock setup" from "mock verification".