### PR TITLE
Response template extensions

### DIFF
--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -43,19 +43,24 @@ impl Default for ResponseTemplate {
 // Same principle applies to allocation/cloning, freely used where convenient.
 impl ResponseTemplate {
     /// Start building a `ResponseTemplate` specifying the status code of the response.
-    pub fn new<S>(s: S) -> Self
-    where
-        S: TryInto<StatusCode>,
-        <S as TryInto<StatusCode>>::Error: std::fmt::Debug,
+    pub fn new<StatusLike>(status: StatusLike) -> Self
+        where
+            StatusLike: TryInto<StatusCode>,
+            <StatusLike as TryInto<StatusCode>>::Error: std::fmt::Debug,
     {
-        let status_code = s.try_into().expect("Failed to convert into status code.");
-        Self {
-            status_code,
-            headers: HashMap::new(),
-            mime: None,
-            body: None,
-            delay: None,
-        }
+        Self::default().set_status_code(status)
+    }
+
+    /// Set the response's [`status code`](StatusCode).
+    pub fn set_status_code<StatusLike>(mut self, status: StatusLike) -> Self
+        where
+            StatusLike: TryInto<StatusCode>,
+            <StatusLike as TryInto<StatusCode>>::Error: std::fmt::Debug,
+    {
+        self.status_code = status
+            .try_into()
+            .expect("Failed to convert into status code.");
+        self
     }
 
     /// Append a header `value` to list of headers with `key` as header name.

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -19,6 +19,20 @@ pub struct ResponseTemplate {
     delay: Option<Duration>,
 }
 
+impl Default for ResponseTemplate {
+    /// Create an "empty" response with `wiremock`'s
+    /// default status of [`404: Not Found`](StatusCode::NotFound).
+    fn default() -> Self {
+        Self {
+            status_code: StatusCode::NotFound,
+            headers: HashMap::new(),
+            mime: None,
+            body: None,
+            delay: None,
+        }
+    }
+}
+
 // `wiremock` is a crate meant for testing - failures are most likely not handled/temporary mistakes.
 // Hence we prefer to panic and provide an easier API than to use `Result`s thus pushing
 // the burden of "correctness" (and conversions) on the user.


### PR DESCRIPTION
*Issue #, if available:* `N/A`

*Description of changes:* -

PR adds a [`Default`](https://github.com/the-wondersmith/wiremock-rs/blob/response-template-extensions/src/response_template.rs#L22) impl and [`set_status_code`](https://github.com/the-wondersmith/wiremock-rs/blob/response-template-extensions/src/response_template.rs#L55) method to the [`wiremock::ResponseTemplate`](https://docs.rs/wiremock/latest/wiremock/struct.ResponseTemplate.html) struct. The intention of the change is to support abstracting / encapsulating repetitive response creation into discrete functions. For example, writing tests for a client library whose target API _always_ returns a JSON response of _some_ kind but whose responses are only _almost_ always 200.

For example, given:

```rust
use http::StatusCode;
use http_types::{headers::CONTENT_TYPE, mime::JSON};
use wiremock::{
    http::{HeaderName, HeaderValue},
    Request, ResponseTemplate,
};


const FIELD_ERROR: &str = r#"{"errors":{"default":"invalid or missing query parameter"}}"#;
const AUTH_KEY_ERROR: &str = r#"{"errors": {"user": "not authorized or over daily test limit for untrusted domains"}}"#;


fn field_error_response(_: &Request) -> ResponseTemplate {
    ResponseTemplate::new(StatusCode::BAD_REQUEST).set_body_raw(FIELD_ERROR, &JSON.to_string())
}

fn bad_api_key_response(_: &Request) -> ResponseTemplate {
    ResponseTemplate::new(StatusCode::UNAUTHORIZED).set_body_raw(AUTH_KEY_ERROR, &JSON.to_string())
}
```

Some of the repetition in the two response functions can be abstracted into a common function like:

```rust
fn raw_json_response(from: &'static str) -> ResponseTemplate {
    ResponseTemplate::default().set_body_raw(from, &JSON.to_string())
}
```

which then allows users to write the two responders above as:

```rust
fn field_error_response(_: &Request) -> ResponseTemplate {
    raw_json_response(FIELD_ERROR).set_status_code(StatusCode::BAD_REQUEST)
}

fn bad_api_key_response(_: &Request) -> ResponseTemplate {
    raw_json_response(AUTH_KEY_ERROR).set_status_code(StatusCode::UNAUTHORIZED)
}
```

Granted, this example is _extremely_ trivial and doesn't appear to save a _ton_ of code. (Also, yes, I know the [`set_body_json`](https://docs.rs/wiremock/latest/wiremock/struct.ResponseTemplate.html#method.set_body_json) method basically does almost exactly this). In my specific case it _does_ actually end up saving a non-trivial amount of code / boilerplate / repetition, so I figured I couldn't be the only one in that boat `¯\(ツ)/¯`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
