### PR TITLE
Add MockGuard::is_satisfied

### DIFF
--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -144,6 +144,7 @@ impl BareMockServer {
     }
 
     /// Return a vector with all the requests received by the `BareMockServer` since it started.
+    ///
     /// If no request has been served, it returns an empty vector.
     ///
     /// If request recording was disabled, it returns `None`.
@@ -211,6 +212,24 @@ impl MockGuard {
         mounted_mock.received_requests()
     }
 
+    /// Have the expectations been satisfied for the [`Mock`] being guarded?
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use tokio::time::sleep;
+    /// use wiremock::MockGuard;
+    ///
+    /// /// Wait up to 100ms for the mock to be satisfied.
+    /// async fn wait_until_satisfied(guard: MockGuard) {
+    ///     for _ in [1..=10] {
+    ///         sleep(Duration::from_millis(10)).await;
+    ///         if guard.is_satisfied().await {
+    ///             return
+    ///         }
+    ///     }
+    ///     // If not satisfied, `guard` gets dropped here and panics.
+    /// }
+    /// ```
     pub async fn is_satisfied(&self) -> bool {
         let MockGuard {
             mock_id,


### PR DESCRIPTION
The intention here is to make it easier to handle situations where we don't know when to expect the mock to be called.

For example, when testing async message consumers, the tests might publish a message and need to assert that the message consumer sent an HTTP request.

Unlike request/response-style HTTP endpoints, the tests don't know when the message consumer has finished processing.

In these cases, one technique is to wait for an expected condition to become true, e.g. a mock being called!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
