### PR TITLE
async satisfaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1"
 futures-timer = "3.0.2"
 futures = "0.3.5"
 hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1.5.0", features = ["rt", "io-util", "time"] }
+tokio = { version = "1.5.0", features = ["rt"] }
 deadpool = "0.9.2"
 async-trait = "0.1"
 once_cell = "1"

--- a/src/mounted_mock.rs
+++ b/src/mounted_mock.rs
@@ -1,3 +1,7 @@
+use std::sync::{atomic::AtomicBool, Arc};
+
+use tokio::sync::Notify;
+
 use crate::{verification::VerificationReport, Match, Mock, Request, ResponseTemplate};
 
 /// Given the behaviour specification as a [`Mock`](crate::Mock), keep track of runtime information
@@ -14,6 +18,8 @@ pub(crate) struct MountedMock {
 
     // matched requests:
     matched_requests: Vec<crate::Request>,
+
+    notify: Arc<(Notify, AtomicBool)>,
 }
 
 impl MountedMock {
@@ -23,6 +29,7 @@ impl MountedMock {
             n_matched_requests: 0,
             position_in_set,
             matched_requests: Vec::new(),
+            notify: Arc::new((Notify::new(), AtomicBool::new(false))),
         }
     }
 
@@ -46,7 +53,19 @@ impl MountedMock {
                 // Increase match count
                 self.n_matched_requests += 1;
                 // Keep track of request
-                self.matched_requests.push(request.clone())
+                self.matched_requests.push(request.clone());
+
+                // notification of satisfaction
+                if self
+                    .specification
+                    .expectation_range
+                    .contains(self.n_matched_requests)
+                {
+                    self.notify
+                        .1
+                        .store(true, std::sync::atomic::Ordering::Release);
+                    self.notify.0.notify_waiters();
+                }
             }
 
             matched
@@ -70,5 +89,9 @@ impl MountedMock {
 
     pub(crate) fn received_requests(&self) -> Vec<crate::Request> {
         self.matched_requests.clone()
+    }
+
+    pub(crate) fn notify(&self) -> Arc<(Notify, AtomicBool)> {
+        self.notify.clone()
     }
 }

--- a/src/mounted_mock.rs
+++ b/src/mounted_mock.rs
@@ -56,11 +56,8 @@ impl MountedMock {
                 self.matched_requests.push(request.clone());
 
                 // notification of satisfaction
-                if self
-                    .specification
-                    .expectation_range
-                    .contains(self.n_matched_requests)
-                {
+                if self.verify().is_satisfied() {
+                    // always set the satisfaction flag **before** raising the event
                     self.notify
                         .1
                         .store(true, std::sync::atomic::Ordering::Release);

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -306,12 +306,12 @@ async fn use_mock_guard_to_await_satisfaction_readiness() {
 
     // Assert
     satisfy
-        .satisfied()
+        .wait_until_satisfied()
         .now_or_never()
         .expect("should be satisfied immediately");
 
     eventually_satisfy
-        .satisfied()
+        .wait_until_satisfied()
         .now_or_never()
         .ok_or(())
         .expect_err("should not be satisfied yet");
@@ -327,14 +327,14 @@ async fn use_mock_guard_to_await_satisfaction_readiness() {
 
     // Assert
     eventually_satisfy
-        .satisfied()
+        .wait_until_satisfied()
         .now_or_never()
         .ok_or(())
         .expect_err("should not be satisfied yet");
 
     async_std::io::timeout(
         Duration::from_millis(100),
-        eventually_satisfy.satisfied().map(Ok),
+        eventually_satisfy.wait_until_satisfied().map(Ok),
     )
     .await
     .expect("should be satisfied");

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -318,7 +318,7 @@ async fn use_mock_guard_to_await_satisfaction_readiness() {
 
     // Act two
     async_std::task::spawn(async move {
-        async_std::task::sleep(Duration::from_millis(50)).await;
+        async_std::task::sleep(Duration::from_millis(100)).await;
         let response = surf::post(format!("{uri}/eventually_satisfy"))
             .await
             .unwrap();
@@ -333,7 +333,7 @@ async fn use_mock_guard_to_await_satisfaction_readiness() {
         .expect_err("should not be satisfied yet");
 
     async_std::io::timeout(
-        Duration::from_millis(100),
+        Duration::from_millis(1000),
         eventually_satisfy.wait_until_satisfied().map(Ok),
     )
     .await


### PR DESCRIPTION
Similar to #116 but slightly different execution. (code is not how I want it to be yet, and the tests don't yet pass. this is purely to demonstrate the extra complexity this adds).

The original `is_satisfied` API was designed around the idea we could poll in a backoff loop for a mock to have received its expected calls. The compelling use case here is triggering an async action through a message queue, and expecting a HTTP request eventually.

Instead of using polls with a retry loop, we could instead utilise the tools Rust gives us with async futures. These are already poll loops, but with reactive management rather than passive timers. This seems more correct to me.

I would also have liked to make `satisfied` take a timeout duration by default, but given this library is async runtime agnostic, I'd rather not break that here

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
