### PR TITLE
Update README with state of mockito

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ Check the table below to see how `wiremock` compares to them across the followin
 - Spying (e.g. verify that a mock has/hasn't been called in a test);
 - Standalone mode (i.e. can I launch an HTTP mock server outside of a test suite?).
 
-|           | Test execution strategy | How many APIs can I mock? | Out-of-the-box request matchers | Extensible request matching | API   | Spying | Standalone mode |
-|-----------|-------------------------|---------------------------|---------------------------------|----------------------------|-------|----------|-----------------|
-| mockito   | ❌ Sequential           | ❌ 1                        | ✔                           | ❌                        | Sync  | ✔     | ❌              |
-| httpmock  | ✔ Parallel              | ✔ Unbounded                | ✔                           | ✔                        | Async/Sync  | ✔     | ✔              |
-| wiremock  | ✔ Parallel ️             | ✔ Unbounded                | ✔                           | ✔                       | Async | ✔      | ❌              |
+|           | Test execution strategy | How many APIs can I mock? | Out-of-the-box request matchers | Extensible request matching | API        | Spying | Standalone mode |
+|-----------|-------------------------|---------------------------|---------------------------------|-----------------------------|------------|--------|-----------------|
+| mockito   | ✔ Parallel              | ✔ Unbounded               | ✔                               | ❌                          | Async/Sync | ✔      | ❌              |
+| httpmock  | ✔ Parallel              | ✔ Unbounded               | ✔                               | ✔                           | Async/Sync | ✔      | ✔               |
+| wiremock  | ✔ Parallel ️             | ✔ Unbounded               | ✔                               | ✔                           | Async      | ✔      | ❌              |
 
 
 ## Future evolution


### PR DESCRIPTION
Hi, 

Mockito has been supporting parallel tests, multiple servers and async since [version 0.32](https://github.com/lipanski/mockito/releases). This PR updates the information in the README. I also aligned the table columns because :eyes: 

Cheers,
Florin.