### PR TITLE
Don't print non-utf8 bodies

### DIFF
--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -1,6 +1,7 @@
 use crate::mock_server::hyper::run_server;
 use crate::mock_set::MockId;
 use crate::mock_set::MountedMockSet;
+use crate::request::BodyPrintLimit;
 use crate::{mock::Mock, verification::VerificationOutcome, Request};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::pin::pin;
@@ -29,7 +30,7 @@ pub(crate) struct BareMockServer {
 pub(super) struct MockServerState {
     mock_set: MountedMockSet,
     received_requests: Option<Vec<Request>>,
-    body_print_limit: usize,
+    body_print_limit: BodyPrintLimit,
 }
 
 impl MockServerState {
@@ -53,7 +54,7 @@ impl BareMockServer {
     pub(super) async fn start(
         listener: TcpListener,
         request_recording: RequestRecording,
-        body_print_limit: usize,
+        body_print_limit: BodyPrintLimit,
     ) -> Self {
         let (shutdown_trigger, shutdown_receiver) = tokio::sync::oneshot::channel();
         let received_requests = match request_recording {

--- a/src/mock_server/builder.rs
+++ b/src/mock_server/builder.rs
@@ -1,6 +1,6 @@
 use crate::mock_server::bare_server::{BareMockServer, RequestRecording};
 use crate::mock_server::exposed_server::InnerServer;
-use crate::request::BODY_PRINT_LIMIT;
+use crate::request::{BodyPrintLimit, BODY_PRINT_LIMIT};
 use crate::MockServer;
 use std::env;
 use std::net::TcpListener;
@@ -10,7 +10,7 @@ use std::net::TcpListener;
 pub struct MockServerBuilder {
     listener: Option<TcpListener>,
     record_incoming_requests: bool,
-    body_print_limit: usize,
+    body_print_limit: BodyPrintLimit,
 }
 
 impl MockServerBuilder {
@@ -19,8 +19,8 @@ impl MockServerBuilder {
             .ok()
             .and_then(|x| x.parse::<usize>().ok())
         {
-            Some(limit) => limit,
-            None => BODY_PRINT_LIMIT,
+            Some(limit) => BodyPrintLimit::Limited(limit),
+            None => BodyPrintLimit::Limited(BODY_PRINT_LIMIT),
         };
         Self {
             listener: None,
@@ -94,20 +94,8 @@ impl MockServerBuilder {
     /// bodies, or when printing wiremock output to a file where size matters
     /// less than in a terminal window. You can configure this limit with
     /// `MockServerBuilder::body_print_limit`.
-    pub fn body_print_limit(mut self, limit: usize) -> Self {
+    pub fn body_print_limit(mut self, limit: BodyPrintLimit) -> Self {
         self.body_print_limit = limit;
-        self
-    }
-
-    /// By default, when printing requests the size of the body that can be
-    /// printed is limited.
-    ///
-    /// This may want to be changed if working with services with very large
-    /// bodies, or when printing wiremock output to a file where size matters
-    /// less than in a terminal window. You can functionally disable this limit
-    /// by calling `MockServerBuilder::disable_body_print_limit`.
-    pub fn disable_body_print_limit(mut self) -> Self {
-        self.body_print_limit = usize::MAX;
         self
     }
 

--- a/src/mock_server/builder.rs
+++ b/src/mock_server/builder.rs
@@ -87,10 +87,10 @@ impl MockServerBuilder {
         self
     }
 
-    /// By default, when printing requests the size of the body that can be
-    /// printed is limited.
+    /// The mock server prints the requests it received when one or more mocks have expectations that have not been satisfied.
+    /// By default, the size of the printed body is limited.
     ///
-    /// This may want to be changed if working with services with very large
+    /// You may want to change this if you're working with services with very large
     /// bodies, or when printing wiremock output to a file where size matters
     /// less than in a terminal window. You can configure this limit with
     /// `MockServerBuilder::body_print_limit`.

--- a/src/request.rs
+++ b/src/request.rs
@@ -44,7 +44,11 @@ impl fmt::Display for Request {
             let values = values.join(",");
             writeln!(f, "{}: {}", name, values)?;
         }
-        writeln!(f, "{}", String::from_utf8_lossy(&self.body))
+        if let Ok(body) = String::from_utf8(self.body.clone()) {
+            writeln!(f, "{}", body)
+        } else {
+            writeln!(f, "Body size is {} bytes", &self.body.len())
+        }
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -44,10 +44,10 @@ impl fmt::Display for Request {
             let values = values.join(",");
             writeln!(f, "{}: {}", name, values)?;
         }
-        if let Ok(body) = String::from_utf8(self.body.clone()) {
+        if let Ok(body) = std::str::from_utf8(&self.body) {
             writeln!(f, "{}", body)
         } else {
-            writeln!(f, "Body size is {} bytes", &self.body.len())
+            writeln!(f, "Body size is {} bytes", self.body.len())
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -60,8 +60,6 @@ impl fmt::Display for Request {
 
         match self.body_print_limit {
             BodyPrintLimit::Limited(limit) if self.body.len() > limit => {
-                // We need to use from_utf8_lossy because the limit may land within a utf8
-                // character.
                 let mut written = false;
                 for end_byte in limit..(limit + 4).max(self.body.len()) {
                     if let Ok(truncated) = std::str::from_utf8(&self.body[..end_byte]) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -55,7 +55,7 @@ impl fmt::Display for Request {
                 self.body.len(),
                 self.body_print_limit
             )?;
-            writeln!(f, "Increase this limit by setting `WIREMOCK_BODY_PRINT_LIMIT`, or `MockServerBuilder::body_print_limit`")
+            writeln!(f, "Increase this limit by setting `WIREMOCK_BODY_PRINT_LIMIT`, or calling `MockServerBuilder::body_print_limit` when building your MockServer instance")
         } else if let Ok(body) = std::str::from_utf8(&self.body) {
             writeln!(f, "{}", body)
         } else {

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,6 +9,16 @@ use http_types::{Method, Url};
 
 pub const BODY_PRINT_LIMIT: usize = 10_000;
 
+/// Specifies limitations on printing request bodies when logging requests. For some mock servers
+/// the bodies may be too large to reasonably print and it may be desireable to limit them.
+#[derive(Debug, Copy, Clone)]
+pub enum BodyPrintLimit {
+    /// Maximum length of a body to print in bytes.
+    Limited(usize),
+    /// There is no limit to the size of a body that may be printed.
+    Unlimited,
+}
+
 /// An incoming request to an instance of [`MockServer`].
 ///
 /// Each matcher gets an immutable reference to a `Request` instance in the [`matches`] method
@@ -33,7 +43,7 @@ pub struct Request {
     pub method: Method,
     pub headers: HashMap<HeaderName, HeaderValues>,
     pub body: Vec<u8>,
-    pub body_print_limit: usize,
+    pub body_print_limit: BodyPrintLimit,
 }
 
 impl fmt::Display for Request {
@@ -48,22 +58,31 @@ impl fmt::Display for Request {
             writeln!(f, "{}: {}", name, values)?;
         }
 
-        if self.body.len() > self.body_print_limit {
-            writeln!(
-                f,
-                "Body is too large to print: {} bytes (limit: {} bytes)",
-                self.body.len(),
-                self.body_print_limit
-            )?;
-            writeln!(f, "Increase this limit by setting `WIREMOCK_BODY_PRINT_LIMIT`, or calling `MockServerBuilder::body_print_limit` when building your MockServer instance")
-        } else if let Ok(body) = std::str::from_utf8(&self.body) {
-            writeln!(f, "{}", body)
-        } else {
-            writeln!(
-                f,
-                "Body is likely binary (invalid utf-8) size is {} bytes",
-                self.body.len()
-            )
+        match self.body_print_limit {
+            BodyPrintLimit::Limited(limit) if self.body.len() > limit => {
+                // We need to use from_utf8_lossy because the limit may land within a utf8
+                // character.
+                let truncated = String::from_utf8_lossy(&self.body[..limit]);
+                writeln!(f, "{}", truncated)?;
+                writeln!(
+                    f,
+                    "We truncated the body because it was too large: {} bytes (limit: {} bytes)",
+                    self.body.len(),
+                    limit
+                )?;
+                writeln!(f, "Increase this limit by setting `WIREMOCK_BODY_PRINT_LIMIT`, or calling `MockServerBuilder::body_print_limit` when building your MockServer instance")
+            }
+            _ => {
+                if let Ok(body) = std::str::from_utf8(&self.body) {
+                    writeln!(f, "{}", body)
+                } else {
+                    writeln!(
+                        f,
+                        "Body is likely binary (invalid utf-8) size is {} bytes",
+                        self.body.len()
+                    )
+                }
+            }
         }
     }
 }
@@ -95,7 +114,7 @@ impl Request {
             method,
             headers,
             body,
-            body_print_limit: BODY_PRINT_LIMIT,
+            body_print_limit: BodyPrintLimit::Limited(BODY_PRINT_LIMIT),
         }
     }
 
@@ -140,7 +159,7 @@ impl Request {
             method,
             headers,
             body,
-            body_print_limit: BODY_PRINT_LIMIT,
+            body_print_limit: BodyPrintLimit::Limited(BODY_PRINT_LIMIT),
         }
     }
 }


### PR DESCRIPTION
A lot of our services take in multipart data or binary data in the HTTP body and when a wiremock predicate fails megabytes of binary data get printed out to the console. Here I address this by not printing out a string if it isn't valid utf8 and instead printing out the body length.

Another alternative may be to put in an upper limit to how large a body will be printed and if it exceeds that size maybe saving the request to a file for later analysis. But this change was so simple I figured I'd open the PR first to start the discussion.

Issue: https://github.com/LukeMathWalker/wiremock-rs/issues/124
