### PR TITLE
use hyperium/http instead of http-rs/http-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,10 @@ serde_json = "1"
 serde = "1"
 regex = "1"
 futures = "0.3.5"
-http = "0.2"
-hyper = { version = "0.14", features = ["full"] }
+http = "1.0"
+http-body-util = "0.1"
+hyper = { version = "1.0", features = ["full"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 tokio = { version = "1.5.0", features = ["rt"] }
 deadpool = "0.9.2"
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/lib.rs"
 
 [dependencies]
 log = "0.4"
-http-types = { version = "2.11", default-features = false, features = ["hyperium_http"] }
 serde_json = "1"
 serde = "1"
 regex = "1"
@@ -33,6 +32,7 @@ async-trait = "0.1"
 once_cell = "1"
 assert-json-diff = "2.0.1"
 base64 = "0.21.0"
+url = "2.2"
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,3 @@ surf = "2.3.2"
 reqwest = "0.11.3"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread"] }
 actix-rt = "2.2.0"
-isahc = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ log = "0.4"
 serde_json = "1"
 serde = "1"
 regex = "1"
-futures-timer = "3.0.2"
 futures = "0.3.5"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.5.0", features = ["rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 serde = "1"
 regex = "1"
 futures = "0.3.5"
+http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.5.0", features = ["rt"] }
 deadpool = "0.9.2"

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,3 @@
 //! Convenient re-exports of http types that are part of `wiremock`'s public API.
-pub use http::{HeaderName, HeaderValue};
-pub use hyper::{HeaderMap, Method};
+pub use http::{HeaderMap, HeaderName, HeaderValue, Method};
 pub use url::Url;

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,4 @@
-//! Convenient re-exports of `http-types`' types that are part of `wiremock`'s public API.
-pub use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
-pub use http_types::{Method, Url};
+//! Convenient re-exports of http types that are part of `wiremock`'s public API.
+pub use hyper::header::{HeaderName, HeaderValue};
+pub use hyper::{HeaderMap, Method};
+pub use url::Url;

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
 //! Convenient re-exports of http types that are part of `wiremock`'s public API.
-pub use hyper::header::{HeaderName, HeaderValue};
+pub use http::{HeaderName, HeaderValue};
 pub use hyper::{HeaderMap, Method};
 pub use url::Url;

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -10,8 +10,7 @@
 use crate::{Match, Request};
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode};
 use base64::prelude::{Engine as _, BASE64_STANDARD};
-use http::{HeaderName, HeaderValue};
-use hyper::Method;
+use http::{HeaderName, HeaderValue, Method};
 use log::debug;
 use regex::Regex;
 use serde::Serialize;

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -394,13 +394,13 @@ impl Match for HeaderExactMatcher {
             .get_all(&self.0)
             .iter()
             .filter_map(|v| v.to_str().ok())
-            .flat_map(|v| v.split(','))
-            .map(|v| HeaderValue::from_str(v.trim()).unwrap())
+            .flat_map(|v| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter_map(|v| HeaderValue::from_str(v).ok())
+            })
             .collect::<Vec<_>>();
-        if values.len() != self.1.len() {
-            return false;
-        }
-        values.into_iter().all(|value| self.1.contains(&value))
+        values == self.1 // order matters
     }
 }
 

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -17,7 +17,6 @@ use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
 use std::convert::TryInto;
-use std::ops::Deref;
 use std::str;
 use url::Url;
 
@@ -1049,7 +1048,7 @@ impl BasicAuthMatcher {
     pub fn from_token(token: impl AsRef<str>) -> Self {
         Self(header(
             "Authorization",
-            format!("Basic {}", token.as_ref()).deref(),
+            &*format!("Basic {}", token.as_ref()),
         ))
     }
 }
@@ -1106,7 +1105,7 @@ impl BearerTokenMatcher {
     pub fn from_token(token: impl AsRef<str>) -> Self {
         Self(header(
             "Authorization",
-            format!("Bearer {}", token.as_ref()).deref(),
+            &*format!("Bearer {}", token.as_ref()),
         ))
     }
 }

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -10,8 +10,8 @@
 use crate::{Match, Request};
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode};
 use base64::prelude::{Engine as _, BASE64_STANDARD};
-use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
-use http_types::{Method, Url};
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::Method;
 use log::debug;
 use regex::Regex;
 use serde::Serialize;
@@ -19,6 +19,7 @@ use serde_json::Value;
 use std::convert::TryInto;
 use std::ops::Deref;
 use std::str;
+use url::Url;
 
 /// Implement the `Match` trait for all closures, out of the box,
 /// if their signature is compatible.
@@ -342,7 +343,7 @@ impl Match for PathRegexMatcher {
 ///     assert_eq!(status, 200);
 /// }
 /// ```
-pub struct HeaderExactMatcher(HeaderName, HeaderValues);
+pub struct HeaderExactMatcher(HeaderName, Vec<HeaderValue>);
 
 /// Shorthand for [`HeaderExactMatcher::new`].
 pub fn header<K, V>(key: K, value: V) -> HeaderExactMatcher
@@ -352,7 +353,7 @@ where
     V: TryInto<HeaderValue>,
     <V as TryInto<HeaderValue>>::Error: std::fmt::Debug,
 {
-    HeaderExactMatcher::new(key, value.try_into().map(HeaderValues::from).unwrap())
+    HeaderExactMatcher::new(key, vec![value])
 }
 
 /// Shorthand for [`HeaderExactMatcher::new`] supporting multi valued headers.
@@ -363,38 +364,44 @@ where
     V: TryInto<HeaderValue>,
     <V as TryInto<HeaderValue>>::Error: std::fmt::Debug,
 {
-    let values = values
-        .into_iter()
-        .filter_map(|v| v.try_into().ok())
-        .collect::<HeaderValues>();
     HeaderExactMatcher::new(key, values)
 }
 
 impl HeaderExactMatcher {
-    pub fn new<K, V>(key: K, value: V) -> Self
+    pub fn new<K, V>(key: K, values: Vec<V>) -> Self
     where
         K: TryInto<HeaderName>,
         <K as TryInto<HeaderName>>::Error: std::fmt::Debug,
-        V: TryInto<HeaderValues>,
-        <V as TryInto<HeaderValues>>::Error: std::fmt::Debug,
+        V: TryInto<HeaderValue>,
+        <V as TryInto<HeaderValue>>::Error: std::fmt::Debug,
     {
         let key = key.try_into().expect("Failed to convert to header name.");
-        let value = value
-            .try_into()
-            .expect("Failed to convert to header value.");
-        Self(key, value)
+        let values = values
+            .into_iter()
+            .map(|value| {
+                value
+                    .try_into()
+                    .expect("Failed to convert to header value.")
+            })
+            .collect();
+        Self(key, values)
     }
 }
 
 impl Match for HeaderExactMatcher {
     fn matches(&self, request: &Request) -> bool {
-        match request.headers.get(&self.0) {
-            None => false,
-            Some(values) => {
-                let headers: Vec<&str> = self.1.iter().map(HeaderValue::as_str).collect();
-                values.eq(headers.as_slice())
-            }
+        let values = request
+            .headers
+            .get_all(&self.0)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .flat_map(|v| v.split(','))
+            .map(|v| HeaderValue::from_str(v.trim()).unwrap())
+            .collect::<Vec<_>>();
+        if values.len() != self.1.len() {
+            return false;
         }
+        values.into_iter().all(|value| self.1.contains(&value))
     }
 }
 
@@ -513,12 +520,16 @@ impl HeaderRegexMatcher {
 
 impl Match for HeaderRegexMatcher {
     fn matches(&self, request: &Request) -> bool {
-        match request.headers.get(&self.0) {
-            None => false,
-            Some(values) => {
-                let has_values = values.iter().next().is_some();
-                has_values && values.iter().all(|v| self.1.is_match(v.as_str()))
-            }
+        let mut it = request
+            .headers
+            .get_all(&self.0)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .peekable();
+        if it.peek().is_some() {
+            it.all(|v| self.1.is_match(v))
+        } else {
+            false
         }
     }
 }
@@ -994,7 +1005,6 @@ where
 /// use wiremock::{MockServer, Mock, ResponseTemplate};
 /// use wiremock::matchers::basic_auth;
 /// use serde::{Deserialize, Serialize};
-/// use http_types::auth::BasicAuth;
 /// use std::convert::TryInto;
 ///
 /// #[async_std::main]
@@ -1008,10 +1018,9 @@ where
 ///         .mount(&mock_server)
 ///         .await;
 ///
-///     let auth = BasicAuth::new("username", "password");
 ///     let client: surf::Client = surf::Config::new()
 ///         .set_base_url(surf::Url::parse(&mock_server.uri()).unwrap())
-///         .add_header(auth.name(), auth.value()).unwrap()
+///         .add_header("Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ=").unwrap()
 ///         .try_into().unwrap();
 ///
 ///     // Act
@@ -1069,7 +1078,6 @@ impl Match for BasicAuthMatcher {
 /// use wiremock::{MockServer, Mock, ResponseTemplate};
 /// use wiremock::matchers::bearer_token;
 /// use serde::{Deserialize, Serialize};
-/// use http_types::auth::BasicAuth;
 ///
 /// #[async_std::main]
 /// async fn main() {

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -10,7 +10,7 @@
 use crate::{Match, Request};
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode};
 use base64::prelude::{Engine as _, BASE64_STANDARD};
-use hyper::header::{HeaderName, HeaderValue};
+use http::{HeaderName, HeaderValue};
 use hyper::Method;
 use log::debug;
 use regex::Regex;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -15,7 +15,7 @@ use std::ops::{
 /// use std::convert::TryInto;
 ///
 /// // Check that a header with the specified name exists and its value has an odd length.
-/// pub struct OddHeaderMatcher(hyper::header::HeaderName);
+/// pub struct OddHeaderMatcher(http::HeaderName);
 ///
 /// impl Match for OddHeaderMatcher {
 ///     fn matches(&self, request: &Request) -> bool {
@@ -69,7 +69,7 @@ use std::ops::{
 ///     // Arrange
 ///     let mock_server = MockServer::start().await;
 ///     
-///     let header_name = hyper::header::HeaderName::from_static("custom");
+///     let header_name = http::HeaderName::from_static("custom");
 ///     // Check that a header with the specified name exists and its value has an odd length.
 ///     let matcher = move |request: &Request| {
 ///         match request.headers.get(&header_name) {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -15,13 +15,13 @@ use std::ops::{
 /// use std::convert::TryInto;
 ///
 /// // Check that a header with the specified name exists and its value has an odd length.
-/// pub struct OddHeaderMatcher(http_types::headers::HeaderName);
+/// pub struct OddHeaderMatcher(hyper::header::HeaderName);
 ///
 /// impl Match for OddHeaderMatcher {
 ///     fn matches(&self, request: &Request) -> bool {
 ///         match request.headers.get(&self.0) {
 ///             // We are ignoring multi-valued headers for simplicity
-///             Some(values) => values[0].as_str().len() % 2 == 1,
+///             Some(value) => value.to_str().map(|v| v.len() % 2 == 1).unwrap_or_default(),
 ///             None => false
 ///         }
 ///     }
@@ -69,11 +69,11 @@ use std::ops::{
 ///     // Arrange
 ///     let mock_server = MockServer::start().await;
 ///     
-///     let header_name: http_types::headers::HeaderName = "custom".try_into().unwrap();
+///     let header_name = hyper::header::HeaderName::from_static("custom");
 ///     // Check that a header with the specified name exists and its value has an odd length.
 ///     let matcher = move |request: &Request| {
 ///         match request.headers.get(&header_name) {
-///             Some(values) => values[0].as_str().len() % 2 == 1,
+///             Some(value) => value.to_str().map(|v| v.len() % 2 == 1).unwrap_or_default(),
 ///             None => false
 ///         }
 ///     };

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -539,7 +539,7 @@ impl Mock {
     /// # Limitations
     ///
     /// When expectations of a scoped [`Mock`] are not verified, it will trigger a panic - just like a normal [`Mock`].
-    /// Due to [limitations](https://internals.rust-lang.org/t/should-drop-glue-use-track-caller/13682) in Rust's [`Drop`](std::ops::Drop) trait,
+    /// Due to [limitations](https://internals.rust-lang.org/t/should-drop-glue-use-track-caller/13682) in Rust's [`Drop`] trait,
     /// the panic message will not include the filename and the line location
     /// where the corresponding [`MockGuard`] was dropped - it will point into `wiremock`'s source code.  
     ///
@@ -626,7 +626,7 @@ impl Mock {
         server.register_as_scoped(self).await
     }
 
-    /// Given a [`Request`](crate::Request) build an instance a [`ResponseTemplate`] using
+    /// Given a [`Request`] build an instance a [`ResponseTemplate`] using
     /// the responder associated with the `Mock`.
     pub(crate) fn response_template(&self, request: &Request) -> ResponseTemplate {
         self.response.respond(request)

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -21,7 +21,7 @@ use std::ops::{
 ///     fn matches(&self, request: &Request) -> bool {
 ///         match request.headers.get(&self.0) {
 ///             // We are ignoring multi-valued headers for simplicity
-///             Some(value) => value.to_str().map(|v| v.len() % 2 == 1).unwrap_or_default(),
+///             Some(value) => value.to_str().unwrap_or_default().len() % 2 == 1,
 ///             None => false
 ///         }
 ///     }
@@ -73,7 +73,7 @@ use std::ops::{
 ///     // Check that a header with the specified name exists and its value has an odd length.
 ///     let matcher = move |request: &Request| {
 ///         match request.headers.get(&header_name) {
-///             Some(value) => value.to_str().map(|v| v.len() % 2 == 1).unwrap_or_default(),
+///             Some(value) => value.to_str().unwrap_or_default().len() % 2 == 1,
 ///             None => false
 ///         }
 ///     };

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -76,8 +76,7 @@ impl BareMockServer {
         std::thread::spawn(move || {
             let server_future = run_server(listener, server_state, shutdown_receiver);
 
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
+            let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("Cannot build local tokio runtime");

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -52,7 +52,7 @@ impl MockServerState {
 
 impl BareMockServer {
     /// Start a new instance of a `BareMockServer` listening on the specified
-    /// [`TcpListener`](std::net::TcpListener).
+    /// [`TcpListener`].
     pub(super) async fn start(
         listener: TcpListener,
         request_recording: RequestRecording,

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -3,6 +3,7 @@ use crate::mock_set::MockId;
 use crate::mock_set::MountedMockSet;
 use crate::request::BodyPrintLimit;
 use crate::{mock::Mock, verification::VerificationOutcome, Request};
+use std::fmt::Write;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::pin::pin;
 use std::sync::atomic::AtomicBool;
@@ -285,19 +286,12 @@ impl Drop for MockGuard {
                     if received_requests.is_empty() {
                         "The server did not receive any request.".into()
                     } else {
-                        format!(
-                            "Received requests:\n{}",
-                            received_requests
-                                .iter()
-                                .enumerate()
-                                .map(|(index, request)| {
-                                    format!(
-                                        "- Request #{}\n{}",
-                                        index + 1,
-                                        &format!("\t{}", request)
-                                    )
-                                })
-                                .collect::<String>()
+                        received_requests.iter().enumerate().fold(
+                            "Received requests:\n".to_string(),
+                            |mut message, (index, request)| {
+                                _ = write!(message, "- Request #{}\n\t{}", index + 1, request);
+                                message
+                            },
                         )
                     }
                 } else {

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -80,7 +80,7 @@ impl BareMockServer {
                 .build()
                 .expect("Cannot build local tokio runtime");
 
-            LocalSet::new().block_on(&runtime, server_future)
+            LocalSet::new().block_on(&runtime, server_future);
         });
         for _ in 0..40 {
             if TcpStream::connect_timeout(&server_address, std::time::Duration::from_millis(25))
@@ -162,7 +162,7 @@ impl BareMockServer {
     /// If request recording was disabled, it returns `None`.
     pub(crate) async fn received_requests(&self) -> Option<Vec<Request>> {
         let state = self.state.read().await;
-        state.received_requests.to_owned()
+        state.received_requests.clone()
     }
 }
 
@@ -264,7 +264,7 @@ impl MockGuard {
         }
 
         // await event
-        notification.await
+        notification.await;
     }
 }
 
@@ -312,6 +312,6 @@ impl Drop for MockGuard {
                 state.mock_set.deactivate(*mock_id);
             }
         };
-        futures::executor::block_on(future)
+        futures::executor::block_on(future);
     }
 }

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -37,7 +37,7 @@ impl MockServerState {
     pub(super) async fn handle_request(
         &mut self,
         mut request: Request,
-    ) -> (http_types::Response, Option<futures_timer::Delay>) {
+    ) -> (hyper::Response<hyper::Body>, Option<futures_timer::Delay>) {
         request.body_print_limit = self.body_print_limit;
         // If request recording is enabled, record the incoming request
         // by adding it to the `received_requests` stack

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -38,7 +38,7 @@ impl MockServerState {
     pub(super) async fn handle_request(
         &mut self,
         mut request: Request,
-    ) -> (hyper::Response<hyper::Body>, Option<futures_timer::Delay>) {
+    ) -> (hyper::Response<hyper::Body>, Option<tokio::time::Sleep>) {
         request.body_print_limit = self.body_print_limit;
         // If request recording is enabled, record the incoming request
         // by adding it to the `received_requests` stack
@@ -88,7 +88,7 @@ impl BareMockServer {
             {
                 break;
             }
-            futures_timer::Delay::new(std::time::Duration::from_millis(25)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
 
         Self {

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -423,7 +423,7 @@ impl MockServer {
     ///
     /// ```rust
     /// use wiremock::MockServer;
-    /// use http_types::Method;
+    /// use hyper::Method;
     ///
     /// #[async_std::main]
     /// async fn main() {
@@ -438,7 +438,7 @@ impl MockServer {
     ///     assert_eq!(received_requests.len(), 1);
     ///
     ///     let received_request = &received_requests[0];
-    ///     assert_eq!(received_request.method, Method::Get);
+    ///     assert_eq!(received_request.method, Method::GET);
     ///     assert_eq!(received_request.url.path(), "/");
     ///     assert!(received_request.body.is_empty());
     /// }

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -3,6 +3,7 @@ use crate::mock_server::pool::{get_pooled_mock_server, PooledMockServer};
 use crate::mock_server::MockServerBuilder;
 use crate::{mock::Mock, verification::VerificationOutcome, MockGuard, Request};
 use log::debug;
+use std::fmt::Write;
 use std::net::SocketAddr;
 use std::ops::Deref;
 
@@ -333,24 +334,22 @@ impl MockServer {
                 if received_requests.is_empty() {
                     "The server did not receive any request.".into()
                 } else {
-                    format!(
-                        "Received requests:\n{}",
-                        received_requests
-                            .into_iter()
-                            .enumerate()
-                            .map(|(index, request)| {
-                                format!("- Request #{}\n{}", index + 1, &format!("\t{}", request))
-                            })
-                            .collect::<String>()
+                    received_requests.iter().enumerate().fold(
+                        "Received requests:\n".to_string(),
+                        |mut message, (index, request)| {
+                            _ = write!(message, "- Request #{}\n\t{}", index + 1, request);
+                            message
+                        },
                     )
                 }
             } else {
                 "Enable request recording on the mock server to get the list of incoming requests as part of the panic message.".into()
             };
-            let verifications_errors: String = failed_verifications
-                .iter()
-                .map(|m| format!("- {}\n", m.error_message()))
-                .collect();
+            let verifications_errors: String =
+                failed_verifications.iter().fold(String::new(), |mut s, m| {
+                    _ = write!(s, "- {}\n", m.error_message());
+                    s
+                });
             let error_message = format!(
                 "Verifications failed:\n{}\n{}",
                 verifications_errors, received_requests_message

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -347,7 +347,7 @@ impl MockServer {
             };
             let verifications_errors: String =
                 failed_verifications.iter().fold(String::new(), |mut s, m| {
-                    _ = write!(s, "- {}\n", m.error_message());
+                    _ = writeln!(s, "- {}", m.error_message());
                     s
                 });
             let error_message = format!(

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -48,7 +48,7 @@ impl Deref for InnerServer {
     fn deref(&self) -> &Self::Target {
         match self {
             InnerServer::Bare(b) => b,
-            InnerServer::Pooled(p) => p.deref(),
+            InnerServer::Pooled(p) => p,
         }
     }
 }
@@ -158,7 +158,7 @@ impl MockServer {
     ///
     /// [`mount`]: Mock::mount
     pub async fn register(&self, mock: Mock) {
-        self.0.register(mock).await
+        self.0.register(mock).await;
     }
 
     /// Register a **scoped** [`Mock`] on an instance of `MockServer`.
@@ -482,7 +482,7 @@ impl MockServer {
 impl Drop for MockServer {
     // Clean up when the `MockServer` instance goes out of scope.
     fn drop(&mut self) {
-        futures::executor::block_on(self.verify())
+        futures::executor::block_on(self.verify());
         // The sender half of the channel, `shutdown_trigger`, gets dropped here
         // Triggering the graceful shutdown of the server itself.
     }

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -422,7 +422,7 @@ impl MockServer {
     ///
     /// ```rust
     /// use wiremock::MockServer;
-    /// use hyper::Method;
+    /// use http::Method;
     ///
     /// #[async_std::main]
     /// async fn main() {

--- a/src/mock_server/hyper.rs
+++ b/src/mock_server/hyper.rs
@@ -11,6 +11,9 @@ pub(super) async fn run_server(
     server_state: Arc<RwLock<MockServerState>>,
     mut shutdown_signal: tokio::sync::watch::Receiver<()>,
 ) {
+    listener
+        .set_nonblocking(true)
+        .expect("Cannot set non-blocking mode on TcpListener");
     let listener = TcpListener::from_std(listener).expect("Cannot upgrade TcpListener");
 
     let request_handler = move |request| {

--- a/src/mock_server/hyper.rs
+++ b/src/mock_server/hyper.rs
@@ -1,74 +1,75 @@
 use crate::mock_server::bare_server::MockServerState;
-use hyper::service::{make_service_fn, service_fn};
-use std::net::TcpListener;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
 use std::sync::Arc;
+use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 
 type DynError = Box<dyn std::error::Error + Send + Sync>;
 
 /// The actual HTTP server responding to incoming requests according to the specified mocks.
 pub(super) async fn run_server(
-    listener: TcpListener,
+    listener: std::net::TcpListener,
     server_state: Arc<RwLock<MockServerState>>,
-    shutdown_signal: tokio::sync::oneshot::Receiver<()>,
+    mut shutdown_signal: tokio::sync::watch::Receiver<()>,
 ) {
-    let request_handler = make_service_fn(move |_| {
+    let listener = TcpListener::from_std(listener).expect("Cannot upgrade TcpListener");
+
+    let request_handler = move |request| {
         let server_state = server_state.clone();
         async move {
-            Ok::<_, DynError>(service_fn(move |request: hyper::Request<hyper::Body>| {
-                let server_state = server_state.clone();
-                async move {
-                    let wiremock_request = crate::Request::from_hyper(request).await;
-                    let (response, delay) = server_state
-                        .write()
-                        .await
-                        .handle_request(wiremock_request)
-                        .await;
+            let wiremock_request = crate::Request::from_hyper(request).await;
+            let (response, delay) = server_state
+                .write()
+                .await
+                .handle_request(wiremock_request)
+                .await;
 
-                    // We do not wait for the delay within the handler otherwise we would be
-                    // holding on to the write-side of the `RwLock` on `mock_set`.
-                    // Holding on the lock while waiting prevents us from handling other requests until
-                    // we have waited the whole duration specified in the delay.
-                    // In particular, we cannot perform even perform read-only operation -
-                    // e.g. check that mock assumptions have been verified.
-                    // Using long delays in tests without handling the delay as we are doing here
-                    // caused tests to hang (see https://github.com/seanmonstar/reqwest/issues/1147)
-                    if let Some(delay) = delay {
-                        delay.await;
-                    }
+            // We do not wait for the delay within the handler otherwise we would be
+            // holding on to the write-side of the `RwLock` on `mock_set`.
+            // Holding on the lock while waiting prevents us from handling other requests until
+            // we have waited the whole duration specified in the delay.
+            // In particular, we cannot perform even perform read-only operation -
+            // e.g. check that mock assumptions have been verified.
+            // Using long delays in tests without handling the delay as we are doing here
+            // caused tests to hang (see https://github.com/seanmonstar/reqwest/issues/1147)
+            if let Some(delay) = delay {
+                delay.await;
+            }
 
-                    Ok::<_, DynError>(response)
-                }
-            }))
+            Ok::<_, DynError>(response)
         }
-    });
+    };
 
-    let server = hyper::Server::from_tcp(listener)
-        .unwrap()
-        .executor(LocalExec)
-        .serve(request_handler)
-        .with_graceful_shutdown(async {
-            // This futures resolves when either:
-            // - the sender half of the channel gets dropped (i.e. MockServer is dropped)
-            // - the sender is used, therefore sending a poison pill willingly as a shutdown signal
-            let _ = shutdown_signal.await;
+    loop {
+        let (stream, _) = tokio::select! { biased;
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok(accepted) => accepted,
+                    Err(_) => break,
+                }
+            },
+            _ = shutdown_signal.changed() => {
+                log::info!("Mock server shutting down");
+                break;
+            }
+        };
+        let io = TokioIo::new(stream);
+
+        let request_handler = request_handler.clone();
+        let mut shutdown_signal = shutdown_signal.clone();
+        tokio::task::spawn_local(async move {
+            let conn = hyper::server::conn::http1::Builder::new()
+                .serve_connection(io, service_fn(request_handler))
+                .with_upgrades();
+            tokio::pin!(conn);
+
+            loop {
+                tokio::select! {
+                    _ = conn.as_mut() => break,
+                    _ = shutdown_signal.changed() => conn.as_mut().graceful_shutdown(),
+                }
+            }
         });
-
-    if let Err(e) = server.await {
-        panic!("Mock server failed: {}", e);
-    }
-}
-
-// An executor that can spawn !Send futures.
-#[derive(Clone, Copy, Debug)]
-struct LocalExec;
-
-impl<F> hyper::rt::Executor<F> for LocalExec
-where
-    F: std::future::Future + 'static, // not requiring `Send`
-{
-    fn execute(&self, fut: F) {
-        // This will spawn into the currently running `LocalSet`.
-        tokio::task::spawn_local(fut);
     }
 }

--- a/src/mock_server/hyper.rs
+++ b/src/mock_server/hyper.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 
-type DynError = Box<dyn std::error::Error + Send + Sync>;
-
 /// The actual HTTP server responding to incoming requests according to the specified mocks.
 pub(super) async fn run_server(
     listener: std::net::TcpListener,
@@ -37,7 +35,7 @@ pub(super) async fn run_server(
                 delay.await;
             }
 
-            Ok::<_, DynError>(response)
+            Ok::<_, &'static str>(response)
         }
     };
 
@@ -58,7 +56,7 @@ pub(super) async fn run_server(
 
         let request_handler = request_handler.clone();
         let mut shutdown_signal = shutdown_signal.clone();
-        tokio::task::spawn_local(async move {
+        tokio::task::spawn(async move {
             let conn = hyper::server::conn::http1::Builder::new()
                 .serve_connection(io, service_fn(request_handler))
                 .with_upgrades();

--- a/src/mock_set.rs
+++ b/src/mock_set.rs
@@ -40,7 +40,7 @@ pub(crate) struct MockId {
 }
 
 impl MountedMockSet {
-    /// Create a new instance of MockSet.
+    /// Create a new instance of `MockSet`.
     pub(crate) fn new() -> MountedMockSet {
         MountedMockSet {
             mocks: vec![],
@@ -65,7 +65,7 @@ impl MountedMockSet {
             }
         }
         if let Some(response_template) = response_template {
-            let delay = response_template.delay().map(|d| Delay::new(d.to_owned()));
+            let delay = response_template.delay().map(Delay::new);
             (response_template.generate_response(), delay)
         } else {
             debug!("Got unexpected request:\n{}", request);

--- a/src/mock_set.rs
+++ b/src/mock_set.rs
@@ -3,6 +3,8 @@ use crate::{
     verification::{VerificationOutcome, VerificationReport},
 };
 use crate::{Mock, Request, ResponseTemplate};
+use http_body_util::Full;
+use hyper::body::Bytes;
 use log::debug;
 use std::{
     ops::{Index, IndexMut},
@@ -51,7 +53,7 @@ impl MountedMockSet {
     pub(crate) async fn handle_request(
         &mut self,
         request: Request,
-    ) -> (hyper::Response<hyper::Body>, Option<Sleep>) {
+    ) -> (hyper::Response<Full<Bytes>>, Option<Sleep>) {
         debug!("Handling request.");
         let mut response_template: Option<ResponseTemplate> = None;
         self.mocks.sort_by_key(|(m, _)| m.specification.priority);
@@ -72,7 +74,7 @@ impl MountedMockSet {
             (
                 hyper::Response::builder()
                     .status(hyper::StatusCode::NOT_FOUND)
-                    .body(hyper::Body::empty())
+                    .body(Full::default())
                     .unwrap(),
                 None,
             )

--- a/src/mounted_mock.rs
+++ b/src/mounted_mock.rs
@@ -4,7 +4,7 @@ use tokio::sync::Notify;
 
 use crate::{verification::VerificationReport, Match, Mock, Request, ResponseTemplate};
 
-/// Given the behaviour specification as a [`Mock`](crate::Mock), keep track of runtime information
+/// Given the behaviour specification as a [`Mock`], keep track of runtime information
 /// concerning this mock - e.g. how many times it matched on a incoming request.
 pub(crate) struct MountedMock {
     pub(crate) specification: Mock,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,11 +1,8 @@
-use std::iter::FromIterator;
-use std::str::FromStr;
-use std::{collections::HashMap, fmt};
+use std::fmt;
 
-use futures::AsyncReadExt;
-use http_types::convert::DeserializeOwned;
-use http_types::headers::{HeaderName, HeaderValue, HeaderValues};
-use http_types::{Method, Url};
+use hyper::{HeaderMap, Method};
+use serde::de::DeserializeOwned;
+use url::Url;
 
 pub const BODY_PRINT_LIMIT: usize = 10_000;
 
@@ -41,7 +38,7 @@ pub enum BodyPrintLimit {
 pub struct Request {
     pub url: Url,
     pub method: Method,
-    pub headers: HashMap<HeaderName, HeaderValues>,
+    pub headers: HeaderMap,
     pub body: Vec<u8>,
     pub body_print_limit: BodyPrintLimit,
 }
@@ -49,10 +46,12 @@ pub struct Request {
 impl fmt::Display for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "{} {}", self.method, self.url)?;
-        for (name, values) in &self.headers {
-            let values = values
+        for name in self.headers.keys() {
+            let values = self
+                .headers
+                .get_all(name)
                 .iter()
-                .map(|value| format!("{}", value))
+                .map(|value| String::from_utf8_lossy(value.as_bytes()))
                 .collect::<Vec<_>>();
             let values = values.join(",");
             writeln!(f, "{}: {}", name, values)?;
@@ -107,62 +106,14 @@ impl Request {
         serde_json::from_slice(&self.body)
     }
 
-    pub async fn from(mut request: http_types::Request) -> Request {
-        let method = request.method();
-        let url = request.url().to_owned();
-
-        let mut headers = HashMap::new();
-        for (header_name, header_values) in &request {
-            headers.insert(header_name.to_owned(), header_values.to_owned());
-        }
-
-        let mut body: Vec<u8> = vec![];
-        request
-            .take_body()
-            .into_reader()
-            .read_to_end(&mut body)
-            .await
-            .expect("Failed to read body");
-
-        Self {
-            url,
-            method,
-            headers,
-            body,
-            body_print_limit: BodyPrintLimit::Limited(BODY_PRINT_LIMIT),
-        }
-    }
-
     pub(crate) async fn from_hyper(request: hyper::Request<hyper::Body>) -> Request {
         let (parts, body) = request.into_parts();
-        let method = parts.method.into();
         let url = match parts.uri.authority() {
             Some(_) => parts.uri.to_string(),
             None => format!("http://localhost{}", parts.uri),
         }
         .parse()
         .unwrap();
-
-        let mut headers = HashMap::new();
-        for name in parts.headers.keys() {
-            let name = name.as_str().as_bytes().to_owned();
-            let name = HeaderName::from_bytes(name).unwrap();
-            let values = parts.headers.get_all(name.as_str());
-            for value in values {
-                let value = value.as_bytes().to_owned();
-                let value = HeaderValue::from_bytes(value).unwrap();
-                let value_parts = value.as_str().split(',');
-                let value_parts = value_parts
-                    .map(|it| it.trim())
-                    .filter_map(|it| HeaderValue::from_str(it).ok());
-                headers
-                    .entry(name.clone())
-                    .and_modify(|values: &mut HeaderValues| {
-                        values.append(&mut HeaderValues::from_iter(value_parts.clone()))
-                    })
-                    .or_insert_with(|| value_parts.collect());
-            }
-        }
 
         let body = hyper::body::to_bytes(body)
             .await
@@ -171,8 +122,8 @@ impl Request {
 
         Self {
             url,
-            method,
-            headers,
+            method: parts.method,
+            headers: parts.headers,
             body,
             body_print_limit: BodyPrintLimit::Limited(BODY_PRINT_LIMIT),
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
+use http::{HeaderMap, Method};
 use http_body_util::BodyExt;
-use hyper::{HeaderMap, Method};
 use serde::de::DeserializeOwned;
 use url::Url;
 

--- a/src/respond.rs
+++ b/src/respond.rs
@@ -75,7 +75,7 @@ use crate::{Request, ResponseTemplate};
 /// `Respond` that propagates back a request header in the response:
 ///
 /// ```rust
-/// use hyper::header::HeaderName;
+/// use http::HeaderName;
 /// use wiremock::{Match, MockServer, Mock, Request, ResponseTemplate, Respond};
 /// use wiremock::matchers::path;
 /// use std::convert::TryInto;

--- a/src/respond.rs
+++ b/src/respond.rs
@@ -75,7 +75,7 @@ use crate::{Request, ResponseTemplate};
 /// `Respond` that propagates back a request header in the response:
 ///
 /// ```rust
-/// use http_types::headers::HeaderName;
+/// use hyper::header::HeaderName;
 /// use wiremock::{Match, MockServer, Mock, Request, ResponseTemplate, Respond};
 /// use wiremock::matchers::path;
 /// use std::convert::TryInto;
@@ -87,12 +87,12 @@ use crate::{Request, ResponseTemplate};
 ///
 /// impl Respond for CorrelationIdResponder {
 ///     fn respond(&self, request: &Request) -> ResponseTemplate {
+///         const HEADER: HeaderName = HeaderName::from_static("x-correlation-id");
 ///         let mut response_template = self.0.clone();
-///         let header_name = HeaderName::from_str("X-Correlation-Id").unwrap();
-///         if let Some(correlation_id) = request.headers.get(&header_name) {
+///         if let Some(correlation_id) = request.headers.get(&HEADER) {
 ///             response_template = response_template.insert_header(
-///                 header_name,
-///                 correlation_id.last().to_owned()
+///                 HEADER,
+///                 correlation_id.to_owned()
 ///             );
 ///         }
 ///         response_template

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -257,26 +257,18 @@ impl ResponseTemplate {
 
     /// Generate a response from the template.
     pub(crate) fn generate_response(&self) -> Response<Body> {
-        let mut response = Response::default();
+        let mut response = Response::builder()
+            .status(self.status_code);
 
-        // Set status code
-        *response.status_mut() = self.status_code;
-        // Add headers
-        *response.headers_mut() = self.headers.clone();
-
-        // Add body, if specified
-        if let Some(body) = &self.body {
-            *response.body_mut() = body.clone().into();
-        }
-
+        let mut headers = self.headers.clone();
         // Set content-type, if needed
         if !self.mime.is_empty() {
-            response
-                .headers_mut()
-                .insert(hyper::header::CONTENT_TYPE, self.mime.parse().unwrap());
+            headers.insert(hyper::header::CONTENT_TYPE, self.mime.parse().unwrap());
         }
+        *response.headers_mut().unwrap() = headers;
 
-        response
+        let body = self.body.clone().unwrap_or_default();
+        response.body(Body::from(body)).unwrap()
     }
 
     /// Retrieve the response delay.

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -1,7 +1,6 @@
-use http::{HeaderName, HeaderValue};
+use http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode};
 use http_body_util::Full;
 use hyper::body::Bytes;
-use hyper::{HeaderMap, Response, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
 use std::time::Duration;

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -1,4 +1,4 @@
-use hyper::header::{HeaderName, HeaderValue};
+use http::{HeaderName, HeaderValue};
 use hyper::{Body, HeaderMap, Response, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
@@ -263,7 +263,7 @@ impl ResponseTemplate {
         let mut headers = self.headers.clone();
         // Set content-type, if needed
         if !self.mime.is_empty() {
-            headers.insert(hyper::header::CONTENT_TYPE, self.mime.parse().unwrap());
+            headers.insert(http::header::CONTENT_TYPE, self.mime.parse().unwrap());
         }
         *response.headers_mut().unwrap() = headers;
 

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -1,5 +1,7 @@
 use http::{HeaderName, HeaderValue};
-use hyper::{Body, HeaderMap, Response, StatusCode};
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::{HeaderMap, Response, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
 use std::time::Duration;
@@ -256,9 +258,8 @@ impl ResponseTemplate {
     }
 
     /// Generate a response from the template.
-    pub(crate) fn generate_response(&self) -> Response<Body> {
-        let mut response = Response::builder()
-            .status(self.status_code);
+    pub(crate) fn generate_response(&self) -> Response<Full<Bytes>> {
+        let mut response = Response::builder().status(self.status_code);
 
         let mut headers = self.headers.clone();
         // Set content-type, if needed
@@ -268,7 +269,7 @@ impl ResponseTemplate {
         *response.headers_mut().unwrap() = headers;
 
         let body = self.body.clone().unwrap_or_default();
-        response.body(Body::from(body)).unwrap()
+        response.body(body.into()).unwrap()
     }
 
     /// Retrieve the response delay.

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -219,7 +219,6 @@ impl ResponseTemplate {
     ///
     /// ### Example:
     /// ```rust
-    /// use isahc::config::Configurable;
     /// use wiremock::{MockServer, Mock, ResponseTemplate};
     /// use wiremock::matchers::method;
     /// use std::time::Duration;

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -1,9 +1,9 @@
 use futures::FutureExt;
-use http_types::StatusCode;
 use serde::Serialize;
 use serde_json::json;
 use std::net::TcpStream;
 use std::time::Duration;
+use surf::StatusCode;
 use wiremock::matchers::{body_json, body_partial_json, method, path, PathExactMatcher};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/tests/request_header_matching.rs
+++ b/tests/request_header_matching.rs
@@ -1,4 +1,3 @@
-use http::HeaderMap;
 use wiremock::matchers::{basic_auth, bearer_token, header, header_regex, headers, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -88,12 +87,11 @@ async fn should_match_multi_request_header_x() {
     mock_server.register(mock).await;
 
     // Act
-    let mut header_map = HeaderMap::new();
-    header_map.append("cache-control", "no-cache".parse().unwrap());
-    header_map.append("cache-control", "no-store".parse().unwrap());
     let should_match = reqwest::Client::new()
         .get(mock_server.uri())
-        .headers(header_map)
+        // TODO: use a dedicated headers when upgrade reqwest v0.12
+        .header("cache-control", "no-cache")
+        .header("cache-control", "no-store")
         .send()
         .await
         .unwrap();

--- a/tests/request_header_matching.rs
+++ b/tests/request_header_matching.rs
@@ -1,4 +1,4 @@
-use hyper::HeaderMap;
+use http::HeaderMap;
 use wiremock::matchers::{basic_auth, bearer_token, header, header_regex, headers, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 


### PR DESCRIPTION
Fix #123 

Please attention: the exported types `Method` / `HeaderValues` make this a breaking change.

By the way, `hyper` v1.0 will remove `hyper::Body`, but I think it's fine to keep it for now?

--- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
