### PR TITLE
Fix mistake that slipped through review.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -74,6 +74,7 @@ impl fmt::Display for Request {
                             )?;
                             writeln!(f, "Increase this limit by setting `WIREMOCK_BODY_PRINT_LIMIT`, or calling `MockServerBuilder::body_print_limit` when building your MockServer instance")?;
                         }
+                        break;
                     }
                 }
                 if !written {


### PR DESCRIPTION
*Description of changes:*

if the last 4 bytes of the of the truncated body happen to all be valid character boundaries it'll print it 4 times. This adds a break after it's printed to avoid this issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
