### PR TITLE
Support body streams

### DIFF
--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -2,6 +2,7 @@ use crate::mock_server::hyper::run_server;
 use crate::mock_set::MockId;
 use crate::mock_set::MountedMockSet;
 use crate::request::BodyPrintLimit;
+use crate::response_template::BodyStream;
 use crate::{mock::Mock, verification::VerificationOutcome, Request};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::pin::pin;
@@ -37,7 +38,12 @@ impl MockServerState {
     pub(super) async fn handle_request(
         &mut self,
         mut request: Request,
-    ) -> (http_types::Response, Option<futures_timer::Delay>) {
+    ) -> (
+        http_types::Response,
+        Option<BodyStream>,
+        Option<u64>,
+        Option<futures_timer::Delay>,
+    ) {
         request.body_print_limit = self.body_print_limit;
         // If request recording is enabled, record the incoming request
         // by adding it to the `received_requests` stack

--- a/src/response_template.rs
+++ b/src/response_template.rs
@@ -1,4 +1,5 @@
 use futures::stream::{self, BoxStream};
+use futures::{Stream, StreamExt};
 use http_types::headers::{HeaderName, HeaderValue};
 use http_types::{Response, StatusCode};
 use serde::Serialize;
@@ -159,6 +160,32 @@ impl ResponseTemplate {
         self
     }
 
+    /// Set the response body with a stream of bytes.
+    ///
+    /// It sets "Content-Type" to "application/octet-stream".
+    ///
+    /// If the `length` is not set, "Transfer-Encoding" is set to "chunked".
+    ///
+    /// To set a body with a stream of bytes but a different "Content-Type"
+    /// [`set_body_stream_raw`](#method.set_body_stream_raw) can be used.
+    pub fn set_body_bytes_stream<F, B, T>(mut self, body_stream_fn: F, length: Option<u64>) -> Self
+    where
+        F: Fn() -> B + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
+        B: Stream<Item = T> + Send + Sync + 'static,
+        T: TryInto<Vec<u8>>,
+        <T as TryInto<Vec<u8>>>::Error: std::error::Error + Send + Sync + 'static,
+    {
+        self.body_fn = Some(Arc::new(move || {
+            let stream = Box::pin(body_stream_fn().map(|item| {
+                item.try_into().map_err(|err| {
+                    Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>
+                })
+            }));
+            (stream, length)
+        }));
+        self
+    }
+
     /// Set the response body from a JSON-serializable value.
     ///
     /// It sets "Content-Type" to "application/json".
@@ -184,6 +211,33 @@ impl ResponseTemplate {
         let body = body.try_into().expect("Failed to convert into body.");
 
         self.body_fn = Some(wrap_body_in_arc_fn(body.into_bytes()));
+        self.mime = Some(
+            http_types::Mime::from_str("text/plain").expect("Failed to convert into Mime header"),
+        );
+        self
+    }
+
+    /// Set the response body to a stream of strings.
+    ///
+    /// It sets "Content-Type" to "text/plain".
+    ///
+    /// If the `length` is not set, "Transfer-Encoding" is set to "chunked".
+    #[must_use]
+    pub fn set_body_string_stream<F, B, T>(mut self, body_stream_fn: F, length: Option<u64>) -> Self
+    where
+        F: Fn() -> B + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
+        B: Stream<Item = T> + Send + Sync + 'static,
+        T: TryInto<String>,
+        <T as TryInto<String>>::Error: std::error::Error + Send + Sync + 'static,
+    {
+        self.body_fn = Some(Arc::new(move || {
+            let stream = Box::pin(body_stream_fn().map(|item| {
+                item.try_into().map(String::into_bytes).map_err(|err| {
+                    Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>
+                })
+            }));
+            (stream, length)
+        }));
         self.mime = Some(
             http_types::Mime::from_str("text/plain").expect("Failed to convert into Mime header"),
         );
@@ -243,6 +297,80 @@ impl ResponseTemplate {
         self.body_fn = Some(wrap_body_in_arc_fn(body));
         self.mime =
             Some(http_types::Mime::from_str(mime).expect("Failed to convert into Mime header"));
+        self
+    }
+
+    /// Set a raw response body using a stream of data. The mime type needs to be set because the
+    /// raw body could be of any type.
+    ///
+    /// If the `length` is not set, "Transfer-Encoding" is set to "chunked".
+    ///
+    /// It the `mime` parameter is `None`, the "Content-Type" header is set to
+    /// "application/octet-stream
+    ///
+    /// ### Example:
+    /// ```rust
+    /// use surf::http::mime;
+    /// use wiremock::matchers::method;
+    /// use wiremock::{Mock, MockServer, ResponseTemplate};
+    ///
+    /// mod external {
+    ///     use futures::{future, stream, Stream, StreamExt};
+    ///
+    ///     use std::convert::Infallible;
+    ///
+    ///     // This could be a method of a struct that is implemented in another crate and a stream
+    ///     // of strings is returned.
+    ///     pub fn body() -> impl Stream<Item = Result<&'static str, Infallible>> {
+    ///         stream::once(future::ok(r#"{"hello": "#))
+    ///             .chain(stream::once(future::ok(r#""world"}"#)))
+    ///     }
+    /// }
+    ///
+    /// #[async_std::main]
+    /// async fn main() {
+    ///     // Arrange
+    ///     let mock_server = MockServer::start().await;
+    ///     let template =
+    ///         ResponseTemplate::new(200).set_body_raw_stream(external::body, Some(18), Some("application/json"));
+    ///     Mock::given(method("GET"))
+    ///         .respond_with(template)
+    ///         .mount(&mock_server)
+    ///         .await;
+    ///
+    ///     // Act
+    ///     let mut res = surf::get(&mock_server.uri()).await.unwrap();
+    ///     let body = res.body_string().await.unwrap();
+    ///
+    ///     // Assert
+    ///     assert_eq!(body, r#"{"hello": "world"}"#);
+    ///     assert_eq!(res.content_type(), Some(mime::JSON));
+    /// }
+    /// ```
+    #[must_use]
+    pub fn set_body_raw_stream<F, B, T, E>(
+        mut self,
+        body_stream_fn: F,
+        length: Option<u64>,
+        mime: Option<&str>,
+    ) -> Self
+    where
+        F: Fn() -> B + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
+        B: Stream<Item = Result<T, E>> + Send + Sync + 'static,
+        T: TryInto<Vec<u8>>,
+        <T as TryInto<Vec<u8>>>::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        self.body_fn = Some(Arc::new(move || {
+            let stream = Box::pin(body_stream_fn().map(|item| {
+                item.map_err(Into::into)
+                    .and_then(|item| item.try_into().map_err(Into::into))
+            }));
+            (stream, length)
+        }));
+        self.mime = mime.map(|mime| {
+            http_types::Mime::from_str(mime).expect("Failed to convert into Mime header")
+        });
         self
     }
 


### PR DESCRIPTION
*Description of changes:*
Add support to _streaming body_, hopefully without any breaking change (according to [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks), there aren't).

The rationale is that it is useful to simulate delays or errors while receiving the body during tests. 

I tried to unify the stream APIs with the current ones, but unfortunately I have been not been use a trait compatible with both current `TryInto<Vec<u8>/String>` and `Stream`s, mainly because of conflicts with blanket impls (once you `impl<T> X for T where T: TryInto<Vec<u8>>` you cannot implement anything else for `X` AFAIK).

I also realized that we have less controls on errors from body stream than I expected (see `tests/mocks.rs:181-182`), but the feature should be useful anyway.

The added API includes the possibility of specifying the length of the body, because it influences whether the `Transfer-Encoding` header is `chunked` or not.

Interesting enough, I realized (thanks to `cargo-semver-checks`) that I needed to add the `+ RefUnwindSafe + UnwindSafe` bounds to the `BodyFn` type alias to avoid a breaking change on `ResponseTemplate`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
