### PR TITLE
feat: implement Debug trait for MockServer

### DIFF
--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -3,6 +3,7 @@ use crate::mock_set::MockId;
 use crate::mock_set::MountedMockSet;
 use crate::request::BodyPrintLimit;
 use crate::{mock::Mock, verification::VerificationOutcome, Request};
+use std::fmt::Debug;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::pin::pin;
 use std::sync::atomic::AtomicBool;
@@ -162,6 +163,12 @@ impl BareMockServer {
     pub(crate) async fn received_requests(&self) -> Option<Vec<Request>> {
         let state = self.state.read().await;
         state.received_requests.to_owned()
+    }
+}
+
+impl Debug for BareMockServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BareMockServer {{ address: {} }}", self.address())
     }
 }
 

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -38,22 +38,10 @@ pub struct MockServer(InnerServer);
 ///
 /// `InnerServer` implements `Deref<Target=BareMockServer>`, so we never actually have to match
 /// on `InnerServer` in `MockServer` - the compiler does all the boring heavy-lifting for us.
+#[derive(Debug)]
 pub(super) enum InnerServer {
     Bare(BareMockServer),
     Pooled(PooledMockServer),
-}
-
-impl Debug for InnerServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InnerServer::Bare(bare) => bare.fmt(f),
-            InnerServer::Pooled(pooled) => write!(
-                f,
-                "PooledMockServer {{ address: {} }}",
-                pooled.deref().address()
-            ),
-        }
-    }
 }
 
 impl Deref for InnerServer {

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -3,6 +3,7 @@ use crate::mock_server::pool::{get_pooled_mock_server, PooledMockServer};
 use crate::mock_server::MockServerBuilder;
 use crate::{mock::Mock, verification::VerificationOutcome, MockGuard, Request};
 use log::debug;
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::ops::Deref;
 
@@ -477,6 +478,12 @@ impl MockServer {
     /// ```
     pub async fn received_requests(&self) -> Option<Vec<Request>> {
         self.0.received_requests().await
+    }
+}
+
+impl Debug for MockServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MockServer {{ address: {} }}", self.address())
     }
 }
 

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -28,6 +28,7 @@ use std::ops::Deref;
 /// instead of [`MockServer::register`].
 ///
 /// You can register as many [`Mock`]s as your scenario requires on a `MockServer`.
+#[derive(Debug)]
 pub struct MockServer(InnerServer);
 
 /// `MockServer` is either a wrapper around a `BareMockServer` retrieved from an
@@ -40,6 +41,19 @@ pub struct MockServer(InnerServer);
 pub(super) enum InnerServer {
     Bare(BareMockServer),
     Pooled(PooledMockServer),
+}
+
+impl Debug for InnerServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InnerServer::Bare(bare) => bare.fmt(f),
+            InnerServer::Pooled(pooled) => write!(
+                f,
+                "PooledMockServer {{ address: {} }}",
+                pooled.deref().address()
+            ),
+        }
+    }
 }
 
 impl Deref for InnerServer {
@@ -478,12 +492,6 @@ impl MockServer {
     /// ```
     pub async fn received_requests(&self) -> Option<Vec<Request>> {
         self.0.received_requests().await
-    }
-}
-
-impl Debug for MockServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MockServer {{ address: {} }}", self.address())
     }
 }
 

--- a/src/mock_server/pool.rs
+++ b/src/mock_server/pool.rs
@@ -49,6 +49,7 @@ pub(crate) async fn get_pooled_mock_server() -> PooledMockServer {
 /// It:
 /// - creates a new `BareMockServer` if there is none to borrow from the pool;
 /// - "cleans up" used `BareMockServer`s before making them available again for other tests to use.
+#[derive(Debug)]
 pub(crate) struct MockServerPoolManager;
 
 #[async_trait]

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -343,18 +343,23 @@ async fn use_mock_guard_to_await_satisfaction_readiness() {
 #[async_std::test]
 async fn debug_prints_mock_server_variants() {
     let pooled_mock_server = MockServer::start().await;
-    assert_eq!(
-        format!(
-            "MockServer(PooledMockServer {{ address: {} }})",
-            pooled_mock_server.address()
-        ),
-        format!("{:?}", pooled_mock_server)
-    );
+    let pooled_debug_str = format!("{:?}", pooled_mock_server);
+
+    assert!(pooled_debug_str.starts_with("MockServer(Pooled(Object {"));
+    assert!(pooled_debug_str
+        .find(
+            format!(
+                "BareMockServer {{ address: {} }}",
+                pooled_mock_server.address()
+            )
+            .as_str()
+        )
+        .is_some());
 
     let bare_mock_server = MockServer::builder().start().await;
     assert_eq!(
         format!(
-            "MockServer(BareMockServer {{ address: {} }})",
+            "MockServer(Bare(BareMockServer {{ address: {} }}))",
             bare_mock_server.address()
         ),
         format!("{:?}", bare_mock_server)

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -339,3 +339,24 @@ async fn use_mock_guard_to_await_satisfaction_readiness() {
     .await
     .expect("should be satisfied");
 }
+
+#[async_std::test]
+async fn debug_prints_mock_server_variants() {
+    let pooled_mock_server = MockServer::start().await;
+    assert_eq!(
+        format!(
+            "MockServer(PooledMockServer {{ address: {} }})",
+            pooled_mock_server.address()
+        ),
+        format!("{:?}", pooled_mock_server)
+    );
+
+    let bare_mock_server = MockServer::builder().start().await;
+    assert_eq!(
+        format!(
+            "MockServer(BareMockServer {{ address: {} }})",
+            bare_mock_server.address()
+        ),
+        format!("{:?}", bare_mock_server)
+    );
+}


### PR DESCRIPTION
*Description of changes:*

Provides an implementation for the `std::fmt::Debug` trait for `wiremock::MockServer`. I thought let's keep it simple, so it just prints the address:

```
MockServer { address: 127.0.0.1:54181 }
```

**Motivation:** [cucumber-rs](https://github.com/cucumber-rs/cucumber) requires all implementations of `cucumber::World` to implement `Debug`. Given all members implement `Debug`, it can be derived:

```rust
#[derive(Default, Debug, cucumber::World)]
World { // keeps all state of a test scenario, therefore mock_server fits well
  ...
  pub mock_server: Option<wiremock::MockServer>, // <- compilation error
}
```

Of course it is possible to implement `Debug` for `World`, but less ergonomic. Hence this PR.

Please tell me what you think - I am happy to provide any changes if required!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
