### PR TITLE
Add `must_use` attribute to `Mock`

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -253,6 +253,7 @@ impl Debug for Matcher {
 /// [`register`]: MockServer::register
 /// [`mount`]: Mock::mount
 /// [`mount_as_scoped`]: Mock::mount_as_scoped
+#[must_use = "`Mock`s have to be mounted or registered with a `MockServer` to become effective"]
 pub struct Mock {
     pub(crate) matchers: Vec<Matcher>,
     pub(crate) response: Box<dyn Respond>,


### PR DESCRIPTION
*Description of changes:*

It's easy to forget to mount a mock to a server, even though the docs call this out. This commit tags the `Mock` struct with [`#[must_use]`][reference], so that Rust itself can warn users when they forget to mount their mocks. The help string

Here's the warning emitted:
```
warning: unused `Mock` that must be used
 --> examples\must_use.rs:9:5
  |
9 |     Mock::given(method("GET")).respond_with(response.clone());
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `Mock`s have to be mounted or registered with a `MockServer` to become effective
  = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
  |
9 |     let _ = Mock::given(method("GET")).respond_with(response.clone());
  |     +++++++
```

[reference]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
