### PR TITLE
Fix newer clippy and rustdoc lints

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -540,7 +540,7 @@ impl Mock {
     /// # Limitations
     ///
     /// When expectations of a scoped [`Mock`] are not verified, it will trigger a panic - just like a normal [`Mock`].
-    /// Due to [limitations](https://internals.rust-lang.org/t/should-drop-glue-use-track-caller/13682) in Rust's [`Drop`](std::ops::Drop) trait,
+    /// Due to [limitations](https://internals.rust-lang.org/t/should-drop-glue-use-track-caller/13682) in Rust's [`Drop`] trait,
     /// the panic message will not include the filename and the line location
     /// where the corresponding [`MockGuard`] was dropped - it will point into `wiremock`'s source code.  
     ///
@@ -627,7 +627,7 @@ impl Mock {
         server.register_as_scoped(self).await
     }
 
-    /// Given a [`Request`](crate::Request) build an instance a [`ResponseTemplate`] using
+    /// Given a [`Request`] build an instance a [`ResponseTemplate`] using
     /// the responder associated with the `Mock`.
     pub(crate) fn response_template(&self, request: &Request) -> ResponseTemplate {
         self.response.respond(request)

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -51,7 +51,7 @@ impl MockServerState {
 
 impl BareMockServer {
     /// Start a new instance of a `BareMockServer` listening on the specified
-    /// [`TcpListener`](std::net::TcpListener).
+    /// [`TcpListener`].
     pub(super) async fn start(
         listener: TcpListener,
         request_recording: RequestRecording,

--- a/src/mock_server/bare_server.rs
+++ b/src/mock_server/bare_server.rs
@@ -3,7 +3,7 @@ use crate::mock_set::MockId;
 use crate::mock_set::MountedMockSet;
 use crate::request::BodyPrintLimit;
 use crate::{mock::Mock, verification::VerificationOutcome, Request};
-use std::fmt::Debug;
+use std::fmt::{Debug, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::pin::pin;
 use std::sync::atomic::AtomicBool;
@@ -292,20 +292,15 @@ impl Drop for MockGuard {
                     if received_requests.is_empty() {
                         "The server did not receive any request.".into()
                     } else {
-                        format!(
-                            "Received requests:\n{}",
-                            received_requests
-                                .iter()
-                                .enumerate()
-                                .map(|(index, request)| {
-                                    format!(
-                                        "- Request #{}\n{}",
-                                        index + 1,
-                                        &format!("\t{}", request)
-                                    )
-                                })
-                                .collect::<String>()
-                        )
+                        let requests = received_requests.iter().enumerate().fold(
+                            String::new(),
+                            |mut r, (index, request)| {
+                                write!(r, "- Request #{idx}\n\t{request}", idx = index + 1,)
+                                    .unwrap();
+                                r
+                            },
+                        );
+                        format!("Received requests:\n{requests}")
                     }
                 } else {
                     "Enable request recording on the mock server to get the list of incoming requests as part of the panic message.".into()

--- a/src/mock_server/exposed_server.rs
+++ b/src/mock_server/exposed_server.rs
@@ -3,7 +3,7 @@ use crate::mock_server::pool::{get_pooled_mock_server, PooledMockServer};
 use crate::mock_server::MockServerBuilder;
 use crate::{mock::Mock, verification::VerificationOutcome, MockGuard, Request};
 use log::debug;
-use std::fmt::Debug;
+use std::fmt::{Debug, Write};
 use std::net::SocketAddr;
 use std::ops::Deref;
 
@@ -336,27 +336,25 @@ impl MockServer {
                 if received_requests.is_empty() {
                     "The server did not receive any request.".into()
                 } else {
-                    format!(
-                        "Received requests:\n{}",
-                        received_requests
-                            .into_iter()
-                            .enumerate()
-                            .map(|(index, request)| {
-                                format!("- Request #{}\n{}", index + 1, &format!("\t{}", request))
-                            })
-                            .collect::<String>()
-                    )
+                    let requests = received_requests.into_iter().enumerate().fold(
+                        String::new(),
+                        |mut r, (index, request)| {
+                            write!(r, "- Request #{idx}\n\t{request}", idx = index + 1).unwrap(); // infallible
+                            r
+                        },
+                    );
+                    format!("Received requests:\n{requests}",)
                 }
             } else {
                 "Enable request recording on the mock server to get the list of incoming requests as part of the panic message.".into()
             };
-            let verifications_errors: String = failed_verifications
-                .iter()
-                .map(|m| format!("- {}\n", m.error_message()))
-                .collect();
+            let verifications_errors =
+                failed_verifications.iter().fold(String::new(), |mut e, m| {
+                    writeln!(e, "- {}", m.error_message()).unwrap(); // infallible
+                    e
+                });
             let error_message = format!(
-                "Verifications failed:\n{}\n{}",
-                verifications_errors, received_requests_message
+                "Verifications failed:\n{verifications_errors}\n{received_requests_message}",
             );
             if std::thread::panicking() {
                 debug!("{}", &error_message);

--- a/src/mounted_mock.rs
+++ b/src/mounted_mock.rs
@@ -4,7 +4,7 @@ use tokio::sync::Notify;
 
 use crate::{verification::VerificationReport, Match, Mock, Request, ResponseTemplate};
 
-/// Given the behaviour specification as a [`Mock`](crate::Mock), keep track of runtime information
+/// Given the behaviour specification as a [`Mock`], keep track of runtime information
 /// concerning this mock - e.g. how many times it matched on a incoming request.
 pub(crate) struct MountedMock {
     pub(crate) specification: Mock,


### PR DESCRIPTION
*Description of changes:*

This PR resolves [clippy::format_collect][fmt] and [rustdoc::redundant_explicit_links][doc], which should unblock the lint and doc CI steps for PRs.

The `format_collect` change is related to building the error messages when mock verification fails. Since it panics with the constructed strings directly, there currently isn't a way to unit-test their content without significant changes, but I did verify manually that the content doesn't change. I also verified that the documentation links being changed still work, though one of them changes from `std::drop::Drop` to `core::drop::Drop`.

As for the code coverage step, the entire [actions-rs](https://github.com/actions-rs) organization has been archived as of October of this year. I don't know what the recommended alternative is.

[fmt]: https://rust-lang.github.io/rust-clippy/master/index.html#/format_collect
[doc]: https://doc.rust-lang.org/rustdoc/lints.html#redundant_explicit_links

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
