### PR TITLE
Update unregistered_mock example to mock a POST

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -160,7 +160,7 @@ impl Debug for Matcher {
 ///     mock_server.register(mock).await;
 ///
 ///     // We won't register this mock instead.
-///     let unregistered_mock = Mock::given(method("GET")).respond_with(response);
+///     let unregistered_mock = Mock::given(method("POST")).respond_with(response);
 ///     
 ///     // Act
 ///     let status = surf::get(&mock_server.uri())


### PR DESCRIPTION
*Issue #, if available:*

n/a
 
*Description of changes:*

Just a tiny update to the example in the docs where `unregistered_mock` is not hit by `surf::post()`. The unregistered mock's method should be POST to demonstrate this, right?



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
