### PR TITLE
Allow h2 requests being mocked.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.5"
 http = "1.0"
 http-body-util = "0.1"
 hyper = { version = "1.0", features = ["full"] }
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "http1", "http2"] }
 tokio = { version = "1.5.0", features = ["rt", "macros"] }
 deadpool = "0.10.0"
 async-trait = "0.1"

--- a/src/mock_server/hyper.rs
+++ b/src/mock_server/hyper.rs
@@ -60,9 +60,9 @@ pub(super) async fn run_server(
         let request_handler = request_handler.clone();
         let mut shutdown_signal = shutdown_signal.clone();
         tokio::task::spawn(async move {
-            let conn = hyper::server::conn::http1::Builder::new()
-                .serve_connection(io, service_fn(request_handler))
-                .with_upgrades();
+            let http_server =
+                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+            let conn = http_server.serve_connection_with_upgrades(io, service_fn(request_handler));
             tokio::pin!(conn);
 
             loop {

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -49,3 +49,26 @@ async fn hello_reqwest_actix() {
 
     assert_eq!(resp.status(), 200);
 }
+
+#[tokio::test]
+async fn hello_reqwest_http2() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let resp = Client::builder()
+        .http2_prior_knowledge()
+        .build()
+        .expect("http client")
+        .get(&mock_server.uri())
+        .send()
+        .await
+        .expect("response");
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.version(), reqwest::Version::HTTP_2);
+}


### PR DESCRIPTION
Version `0.5` was capable to mock h2 requests, but it was probably broken by #128 