### PR TITLE
Implement From<RangeFull> for Times

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -765,6 +765,12 @@ impl From<u64> for Times {
     }
 }
 
+impl From<RangeFull> for Times {
+    fn from(x: RangeFull) -> Self {
+        Times(TimesEnum::Unbounded(x))
+    }
+}
+
 // A quick macro to help easing the implementation pain.
 macro_rules! impl_from_for_range {
     ($type_name:ident) => {


### PR DESCRIPTION
I just noticed this is a bit of an odd one out in the implementation. I believe RangeFull is the default so a user doesn't have to set it explicitly. But if they did just out of idle habit then there wasn't a From conversion.

Not really a big thing but I just figured it would be a mildly nicer DX if `N..` `..N` and `..` all worked as arguments.