### PR TITLE
Update deadpool to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ http-body-util = "0.1"
 hyper = { version = "1.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio", "server", "http1", "http2"] }
 tokio = { version = "1.5.0", features = ["rt", "macros"] }
-deadpool = "0.10.0"
-async-trait = "0.1"
+deadpool = "0.12.0"
 once_cell = "1"
 assert-json-diff = "2.0.1"
 base64 = "0.22"

--- a/src/mock_server/pool.rs
+++ b/src/mock_server/pool.rs
@@ -1,6 +1,5 @@
 use crate::mock_server::bare_server::BareMockServer;
 use crate::MockServer;
-use async_trait::async_trait;
 use deadpool::managed::{Metrics, Object, Pool};
 use once_cell::sync::Lazy;
 use std::convert::Infallible;
@@ -52,7 +51,6 @@ pub(crate) async fn get_pooled_mock_server() -> PooledMockServer {
 #[derive(Debug)]
 pub(crate) struct MockServerPoolManager;
 
-#[async_trait]
 impl deadpool::managed::Manager for MockServerPoolManager {
     type Error = Infallible;
     type Type = BareMockServer;


### PR DESCRIPTION
- Removes the `async-trait` dependency

I will admit that I do not *entirely* understand the async-related change, but it works (`cargo test` passes). The following links are relevant.

- https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits/
- https://github.com/deadpool-rs/deadpool/issues/298
- https://github.com/deadpool-rs/deadpool/discussions/303

(Thanks to @decathorpe for doing a quick sanity-check on this.)