### PR TITLE
feat: support matching form url encoded fields

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use http::{HeaderMap, Method};
 use http_body_util::BodyExt;
 use serde::de::DeserializeOwned;
-use url::Url;
+use url::{form_urlencoded, Url};
 
 pub const BODY_PRINT_LIMIT: usize = 10_000;
 
@@ -46,6 +46,10 @@ pub struct Request {
 impl Request {
     pub fn body_json<T: DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
         serde_json::from_slice(&self.body)
+    }
+
+    pub fn body_form_urlencoded(&self) -> form_urlencoded::Parse<'_> {
+        form_urlencoded::parse(&self.body)
     }
 
     pub(crate) async fn from_hyper(request: hyper::Request<hyper::body::Incoming>) -> Request {

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -4,7 +4,11 @@ use serde_json::json;
 use std::net::TcpStream;
 use std::time::Duration;
 use surf::StatusCode;
-use wiremock::matchers::{body_json, body_partial_json, method, path, PathExactMatcher};
+use url::form_urlencoded;
+use wiremock::matchers::{
+    body_json, body_partial_json, form_url_encoded, form_url_encoded_field_is_missing, method,
+    path, PathExactMatcher,
+};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[async_std::test]
@@ -210,6 +214,61 @@ async fn body_json_partial_matches_a_part_of_response_json() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::Ok);
+}
+
+#[async_std::test]
+async fn body_form_matches_independent_of_key_ordering() {
+    let body = form_urlencoded::Serializer::new(String::new())
+        .append_pair("b", "2")
+        .append_pair("a", "1")
+        .finish();
+
+    let mock_server = MockServer::start().await;
+    let response = ResponseTemplate::new(200);
+    let mock = Mock::given(method("POST"))
+        .and(form_url_encoded("a", "1"))
+        .and(form_url_encoded("b", "2"))
+        .respond_with(response);
+    mock_server.register(mock).await;
+
+    // Act
+    let response = surf::post(mock_server.uri()).body(body).await.unwrap();
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::Ok);
+}
+
+#[async_std::test]
+async fn body_form_partial_matches() {
+    let body: String = form_urlencoded::Serializer::new(String::new())
+        .append_pair("a", "1")
+        .append_pair("b", "2")
+        .finish();
+
+    let mock_server = MockServer::start().await;
+    let response = ResponseTemplate::new(200);
+    let mock = Mock::given(method("POST"))
+        .and(form_url_encoded_field_is_missing("c"))
+        .respond_with(response);
+    mock_server.register(mock).await;
+
+    // Act
+    let response = surf::post(mock_server.uri()).body(body).await.unwrap();
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::Ok);
+
+    let body: String = form_urlencoded::Serializer::new(String::new())
+        .append_pair("a", "1")
+        .append_pair("b", "2")
+        .append_pair("c", "unexpected")
+        .finish();
+
+    // Act
+    let err_response = surf::post(mock_server.uri()).body(body).await.unwrap();
+
+    // Assert
+    assert_eq!(err_response.status(), StatusCode::NotFound);
 }
 
 #[should_panic(expected = "\


### PR DESCRIPTION
For our use case we need to check for the body content that is form-url-encoded. This PR adds support for matching content inside the form and with similar semantics to the query param matchers, but checking against the body. 