### PR TITLE
feature: capture HTTP version in Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use http::{HeaderMap, Method};
+use http::{HeaderMap, Method, Version};
 use http_body_util::BodyExt;
 use serde::de::DeserializeOwned;
 use url::Url;
@@ -41,6 +41,7 @@ pub struct Request {
     pub method: Method,
     pub headers: HeaderMap,
     pub body: Vec<u8>,
+    pub version: Version,
 }
 
 impl Request {
@@ -67,6 +68,7 @@ impl Request {
             url,
             method: parts.method,
             headers: parts.headers,
+            version: parts.version,
             body: body.to_vec(),
         }
     }


### PR DESCRIPTION
This allows responding with info about the HTTP version.

Additionally, expanded a test to cover this.

Note: in the test, we assert resp.version(). However, for my use case I have `test client --> reverse proxy under test --> wiremock`, so I do not have direct access to the response from wiremock. Hence, I want to put more info about the request into the response body/headers.