### PR TITLE
feat: Make method and MethodExactMatcher case in-sensitive

### DIFF
--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
 use std::convert::TryInto;
-use std::str;
+use std::str::{self, FromStr};
 use url::Url;
 
 /// Implement the `Match` trait for all closures, out of the box,
@@ -65,8 +65,7 @@ pub struct MethodExactMatcher(Method);
 /// Shorthand for [`MethodExactMatcher::new`].
 pub fn method<T>(method: T) -> MethodExactMatcher
 where
-    T: TryInto<Method>,
-    <T as TryInto<Method>>::Error: std::fmt::Debug,
+    T: AsRef<str>,
 {
     MethodExactMatcher::new(method)
 }
@@ -74,11 +73,9 @@ where
 impl MethodExactMatcher {
     pub fn new<T>(method: T) -> Self
     where
-        T: TryInto<Method>,
-        <T as TryInto<Method>>::Error: std::fmt::Debug,
+        T: AsRef<str>,
     {
-        let method = method
-            .try_into()
+        let method = Method::from_str(&method.as_ref().to_ascii_uppercase())
             .expect("Failed to convert to HTTP method.");
         Self(method)
     }

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -450,3 +450,44 @@ async fn custom_err() {
     ];
     assert_eq!(actual_err, expected_err);
 }
+
+#[async_std::test]
+async fn method_matcher_is_case_insensitive() {
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let response = ResponseTemplate::new(200).set_body_bytes("world");
+    let mock = Mock::given(method("Get"))
+        .and(PathExactMatcher::new("hello"))
+        .respond_with(response);
+    mock_server.register(mock).await;
+
+    // Act
+    let response = reqwest::get(format!("{}/hello", &mock_server.uri()))
+        .await
+        .unwrap();
+
+    // Assert
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.text().await.unwrap(), "world");
+}
+
+#[async_std::test]
+async fn http_crate_method_can_be_used_directly() {
+    use http::Method;
+    // Arrange
+    let mock_server = MockServer::start().await;
+    let response = ResponseTemplate::new(200).set_body_bytes("world");
+    let mock = Mock::given(method(Method::GET))
+        .and(PathExactMatcher::new("hello"))
+        .respond_with(response);
+    mock_server.register(mock).await;
+
+    // Act
+    let response = reqwest::get(format!("{}/hello", &mock_server.uri()))
+        .await
+        .unwrap();
+
+    // Assert
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.text().await.unwrap(), "world");
+}


### PR DESCRIPTION
Currently a mock defined as `Mock::given(method("Get"))` would fail a test due to the `MethodExactMatcher` being case sensitive.

- Changes `MethodExactMatcher` to allow a mocked method to be case in-sensitive.
Wiremock will automatically convert a provided method to uppercase.
This makes it so both `Mock::given(method("GET"))` and ` Mock::given(method("Get"))` will pass a test.
- Adds a test making sure that `Mock::given(method(Method::Get))` is still compatible.